### PR TITLE
[#86] Added in support to hit enter to submit the current editor

### DIFF
--- a/test/default-editor.html
+++ b/test/default-editor.html
@@ -29,6 +29,8 @@
           document.addEventListener( "keydown", function( e ) {
             if( e.keyCode === 13 ) {
               okPressed( e );
+            } else if( e.keyCode === 27 ) {
+              cancelPressed( e );
             }
           }, false);
           okButton.addEventListener( "click", okPressed, false );

--- a/test/default-editor.html
+++ b/test/default-editor.html
@@ -9,21 +9,30 @@
 
         document.addEventListener( "DOMContentLoaded", function( e ){
           var okButton = document.getElementById( "ok" ),
-              cancelButton = document.getElementById( "cancel" );
+              cancelButton = document.getElementById( "cancel" ),
+              okPressed,
+              cancelPressed;
 
-          okButton.addEventListener( "click", function( e ){
-            
+          okPressed = function( e ) {
             var popcornOptions = {};
             for( var item in _manifest ) {
               popcornOptions[ item ] = document.getElementById( item ).value;
             }
             _comm.send( "submit", popcornOptions);
             _comm.send( "close" );
-          }, false );
+          };
 
-          cancelButton.addEventListener( "click", function( e ){
+          cancelPressed = function( e ) {
             _comm.send( "cancel" );
-          }, false );
+          };
+
+          document.addEventListener( "keydown", function( e ) {
+            if( e.keyCode === 13 ) {
+              okPressed( e );
+            }
+          }, false);
+          okButton.addEventListener( "click", okPressed, false );
+          cancelButton.addEventListener( "click", cancelPressed, false );
 
           _comm.listen( "trackeventdata", function( e ) {
             var popcornOptions = e.data.popcornOptions,

--- a/test/template.js
+++ b/test/template.js
@@ -30,6 +30,7 @@ document.addEventListener( "DOMContentLoaded", function( e ){
 
           butter.plugin.add([
             { name: "footnote", type: "footnote", path: "../external/popcorn-js/plugins/footnote/popcorn.footnote.js" },
+            { name: "attribution", type: "attribution", path: "../external/popcorn-js/plugins/attribution/popcorn.attribution.js" },
             { name: "image", type: "image", path: "../external/popcorn-js/plugins/image/popcorn.image.js" }], function( e ) {
 
             var event = track.addTrackEvent({


### PR DESCRIPTION
As the message says, hitting enter on dialogs now works as expected in both iframes and windows.
