### PR TITLE
Validate a track event's start and end time

### DIFF
--- a/editors/default-editor.html
+++ b/editors/default-editor.html
@@ -1,5 +1,10 @@
 <html>
   <head>
+    <style>
+      p#message {
+        color: #FF0000;
+      }
+    </style>
     <script type="text/javascript" src="../src/dialog/dialog-comm.js"></script>
     <script type="text/javascript">
       (function(){
@@ -19,12 +24,12 @@
             for( var item in _manifest ) {
               popcornOptions[ item ] = document.getElementById( item ).value;
             }
+            document.getElementById( "message" ).innerHTML = "";
             _comm.send( "submit", popcornOptions);
           } //sendData
 
           okPressed = function( e ) {
             sendData();
-            _comm.send( "close" );
           };
 
           cancelPressed = function( e ) {
@@ -46,6 +51,11 @@
               var element = document.getElementById( item );
               element.value = e.data[ item ];
             } //for
+            _comm.send( "close" );
+          });
+
+          _comm.listen( "trackeventupdatefailed", function( e ) {
+            document.getElementById( "message" ).innerHTML = e.data;
           });
 
           _comm.listen( "trackeventdata", function( e ){
@@ -115,5 +125,6 @@
     </table>
     <button id="ok">Ok</button>
     <button id="cancel">Cancel</button>
+    <p id="message"></p>
   </body>
 </html>

--- a/src/core/trackevent.js
+++ b/src/core/trackevent.js
@@ -34,6 +34,18 @@ define( [ "./logger", "./eventmanager", "util/lang" ], function( Logger, EventMa
     _popcornOptions.end = _round( _popcornOptions.end, NUMBER_OF_DECIMAL_PLACES );
 
     this.update = function( updateOptions ) {
+      var errorMessage;
+      if ( updateOptions.start >= _round( butter.duration, NUMBER_OF_DECIMAL_PLACES ) ) {
+        errorMessage = "The in time cannot be greater than or equal to the duration of the video, which is " + _round( butter.duration, NUMBER_OF_DECIMAL_PLACES ) + " seconds.";
+        _em.dispatch( "trackeventupdatefailed", errorMessage );
+        return;
+      } //if
+      if ( updateOptions.end > _round( butter.duration, NUMBER_OF_DECIMAL_PLACES ) ) {
+        errorMessage = "The out time cannot be greater than the duration of the video, which is " + _round( butter.duration, NUMBER_OF_DECIMAL_PLACES ) + " seconds.";
+        _em.dispatch( "trackeventupdatefailed", errorMessage );
+        return;
+      } //if
+
       for ( var prop in updateOptions ) {
         if ( updateOptions.hasOwnProperty( prop ) ) {
           _popcornOptions[ prop ] = updateOptions[ prop ];

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -54,6 +54,10 @@ define( [ "core/eventmanager" ], function( EventManager ) {
         butter.dialog.send( _dialogName, "trackeventupdated", trackEvent.popcornOptions );
       } //onTrackEventUpdated
 
+      function onTrackEventUpdateFailed( e ) {
+        butter.dialog.send( _dialogName, "trackeventupdatefailed", e.data );
+      } //onTrackEventUpdateFailed
+
       butter.dialog.open( _dialogName, {
         open: function( e ) {
           var targets = [];
@@ -66,12 +70,14 @@ define( [ "core/eventmanager" ], function( EventManager ) {
             targets: targets
           });
           trackEvent.listen( "trackeventupdated", onTrackEventUpdated );
+          trackEvent.listen( "trackeventupdatefailed", onTrackEventUpdateFailed );
         },
         submit: function( e ) {
           trackEvent.update( e.data );
         },
         close: function( e ){
           trackEvent.unlisten( "trackeventupdated", onTrackEventUpdated );
+          trackEvent.unlisten( "trackeventupdatefailed", onTrackEventUpdateFailed );
         }
       });
     }; //open


### PR DESCRIPTION
Ensure that a track event's start time is less than the duration of the
video. Also, make sure that a track event's end time is less than or
equal to the video's duration. Display an error message to the user if
any of these conditions are not true.
