### PR TITLE
T413 - Fix Scrollbars jumping when clicked on

### DIFF
--- a/src/timeline/scrollbars.js
+++ b/src/timeline/scrollbars.js
@@ -227,6 +227,9 @@ define( [], function(){
 
       if( posX > handleRect.right ) {
         _handle.style.left = ( ( posX - elementRect.left ) - _handleWidth ) + "px"; 
+      } 
+      else if( posX < handleRect.left ) {
+        _handle.style.left = posX - elementRect.left + "px"; 
       }
       
       p = _handle.offsetLeft / ( _elementWidth - _handleWidth );

--- a/src/timeline/scrollbars.js
+++ b/src/timeline/scrollbars.js
@@ -115,13 +115,12 @@ define( [], function(){
           elementRect = _element.getBoundingClientRect(),
           p;
 
-      if( posY > handleRect.top && posY > handleRect.bottom ) {
+      if( posY > handleRect.bottom ) {
         _handle.style.top = ( ( posY - elementRect.top ) - _handleHeight ) + "px";
-        console.log(_handle.style.top); 
       } else if( posY < handleRect.top ) {
-        _handle.style.top = posY - elementRect.top + "px"; 
+        _handle.style.top = posY - elementRect.top + "px";
       }
-      
+
       p = _handle.offsetTop / ( _elementHeight - _handleHeight );
       _control.scrollTop = ( _control.scrollHeight - _elementHeight ) * p;
     }, false);
@@ -227,12 +226,12 @@ define( [], function(){
           p;
 
       if( posX > handleRect.right ) {
-        _handle.style.left = ( ( posX - elementRect.left ) - _handleWidth ) + "px"; 
-      } 
-      else if( posX < handleRect.left ) {
-        _handle.style.left = posX - elementRect.left + "px"; 
+        _handle.style.left = ( ( posX - elementRect.left ) - _handleWidth ) + "px";
       }
-      
+      else if( posX < handleRect.left ) {
+        _handle.style.left = posX - elementRect.left + "px";
+      }
+
       p = _handle.offsetLeft / ( _elementWidth - _handleWidth );
       _control.scrollLeft = ( _control.scrollWidth - _elementWidth ) * p;
     }, false);

--- a/src/timeline/scrollbars.js
+++ b/src/timeline/scrollbars.js
@@ -115,12 +115,13 @@ define( [], function(){
           elementRect = _element.getBoundingClientRect(),
           p;
 
-      if( posY > handleRect.top ) {
-        _handle.style.top = ( ( posY - elementRect.top ) - _handleHeight ) + "px"; 
-      } else {
+      if( posY > handleRect.top && posY > handleRect.bottom ) {
+        _handle.style.top = ( ( posY - elementRect.top ) - _handleHeight ) + "px";
+        console.log(_handle.style.top); 
+      } else if( posY < handleRect.top ) {
         _handle.style.top = posY - elementRect.top + "px"; 
       }
-
+      
       p = _handle.offsetTop / ( _elementHeight - _handleHeight );
       _control.scrollTop = ( _control.scrollHeight - _elementHeight ) * p;
     }, false);

--- a/src/timeline/scrollbars.js
+++ b/src/timeline/scrollbars.js
@@ -227,8 +227,6 @@ define( [], function(){
 
       if( posX > handleRect.right ) {
         _handle.style.left = ( ( posX - elementRect.left ) - _handleWidth ) + "px"; 
-      } else {
-        _handle.style.left = posX - elementRect.left + "px"; 
       }
       
       p = _handle.offsetLeft / ( _elementWidth - _handleWidth );


### PR DESCRIPTION
Now the handles (vertical and horitzontal) don't shift when clicked on. However the functionality of clicking in other areas of the scrollbar's "container" still properly shift the handle around.
