### PR TITLE
[#444]Drop function no longer fires when trackevents on track are moved and paged is reaaallly zoomed in.

### DIFF
--- a/src/core/media.js
+++ b/src/core/media.js
@@ -184,11 +184,13 @@ THE SOFTWARE.
         } //if
         _pageElement = new PageElement( _target, {
           drop: function( event, ui ){
-            _em.dispatch( "trackeventrequested", {
-              event: event,
-              target: _this,
-              ui: ui
-            });
+            if( event.currentTarget === _this ) {
+              _em.dispatch( "trackeventrequested", {
+                event: event,
+                target: _this,
+                ui: ui
+              });
+            }//if
           }
         },
         {

--- a/src/timeline/track-controller.js
+++ b/src/timeline/track-controller.js
@@ -97,7 +97,6 @@ define( [ "core/trackevent", "core/eventmanager", "./trackevent-controller" ], f
       if( !tlEvent ){
         addTrackEvent( bEvent );
       }
-      //butter.targettedEvent = _bTrackEvent;
     });
 
     _bTrack.listen( "trackeventremoved", function( e ){


### PR DESCRIPTION
This no longer happens, yet old dropping of plugins from tray to elements still works.
