### PR TITLE
Fix error message for invalid start and end times

### DIFF
--- a/editors/default-editor.html
+++ b/editors/default-editor.html
@@ -61,7 +61,13 @@
 
           _comm.listen( "trackeventupdatefailed", function( e ) {
             if( e.data.error === "trackeventupdate::invalidtime" ){
-              document.getElementById( "message" ).innerHTML = "You've entered an invalid start or end time. Please verify that they are both greater than 0, the end time is equal to or less than the media's duration, and that the start time is less than the end time.";
+            document.getElementById( "message" ).innerHTML = 
+            "You have entered an invalid in or out time. Please verify that"
+            + "<ul>"
+            +   "<li>Both in and out times are greater than 0.</li>"
+            +   "<li>The out time is equal to, or less than the media's duration (" + e.data.mediaDuration + " seconds).</li>"
+            +   "<li>The in time is less than the out time.</li>"
+            + "</ul>";
             } //if
           });
 

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -99,6 +99,7 @@ define( [ "core/eventmanager", "dialog/iframe-dialog", "dialog/window-dialog", "
               trackEvent.dispatch( "trackeventupdatefailed", {
                 error: "trackeventupdate::invalidtime",
                 message: "Invalid start/end times.",
+                mediaDuration: duration,
                 attemptedData: popcornData
               });
             }


### PR DESCRIPTION
1. The error message now refers to start and end times as in and out
   times, since that is how it is displayed to the user in the editor.
2. The media's duration is displayed in the error message.
3. The error message is now displayed as a bulleted list for
   readability.
