### PR TITLE
Focus the track event editor when double clicked

### DIFF
--- a/src/dialog/window-dialog.js
+++ b/src/dialog/window-dialog.js
@@ -113,6 +113,10 @@ define( [
       });
     }; //open
 
+    this.focus = function() {
+      _window.focus();
+    } //focus
+
     this.send = function( type, data ){
       if( _comm ){
         _comm.send( type, data );

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -39,6 +39,7 @@ define( [ "core/eventmanager", "dialog/iframe-dialog", "dialog/window-dialog", "
       } //if
 
       if( !_dialog.closed ){
+        _dialog.focus();
         return;
       } //if
 


### PR DESCRIPTION
If the track event editor is already open and the track event is double
clicked, the editor should be in focus.
