### PR TITLE
[t538] - Bug: iframe editor esc require focus

### DIFF
--- a/src/dialog/iframe-dialog.js
+++ b/src/dialog/iframe-dialog.js
@@ -109,6 +109,12 @@ define( [
     }; //send
 
     Object.defineProperties( this, {
+      iframe: {
+        enumerable: true,
+        get: function(){
+          return _iframe;
+        }
+      },
       closed: {
         enumerable: true,
         get: function(){

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -91,6 +91,9 @@ define( [ "core/eventmanager", "dialog/iframe-dialog", "dialog/window-dialog", "
           blinkTarget();
           trackEvent.listen( "trackeventupdated", onTrackEventUpdated );
           trackEvent.listen( "trackeventupdatefailed", onTrackEventUpdateFailed );
+          if( _frameType === "iframe" ){
+            _dialog.iframe.focus();
+          }
         },
         submit: function( e ){
           var duration = TimeUtil.roundTime( butter.currentMedia.duration ),


### PR DESCRIPTION
Added _dialog.iframe.focus when editor uses an iframe after it opens completely.
