### PR TITLE
[t358] - tooltips for trackevents

### DIFF
--- a/src/core/popcorn-wrapper.js
+++ b/src/core/popcorn-wrapper.js
@@ -99,6 +99,16 @@ define( [ "core/logger", "core/eventmanager" ], function( Logger, EventManager )
           _popcorn[ trackEvent.type ]( options );
           // store a local reference to the newly created trackevent
           _butterEventMap[ butterId ] = _popcorn.getLastTrackEventId();
+
+          if( trackEvent.view ){
+            var popcornEvent = _popcorn.getTrackEvent( _butterEventMap[ butterId ] );
+            if( popcornEvent.toString ){
+              trackEvent.view.setToolTip( popcornEvent.toString() );
+            }
+            else{
+              trackEvent.view.setToolTip( JSON.stringify( options ) );
+            }
+          }
         } //if
       } //if
     }; //updateEvent

--- a/src/core/views/trackevent-view.js
+++ b/src/core/views/trackevent-view.js
@@ -36,6 +36,10 @@ define( [ "core/logger", "core/eventmanager", "util/dragndrop" ], function( Logg
       _element.style.width = ( ( _end - _start ) / _duration * _zoom ) + "px";
     } //resetContainer
 
+    this.setToolTip = function( title ){
+      _element.title = title;
+    };
+
     this.update = function( options ){
       options = options || {};
       _element.style.top = "0px";


### PR DESCRIPTION
After a trackevent update, popcorn-wrapper will assign a tooltip to a trackevent
through the setTooltip function, attempting to use new toString() functionality.
