### PR TITLE
[t626] - firefox dialog textareas not full height

### DIFF
--- a/dialogs/dialog.css
+++ b/dialogs/dialog.css
@@ -173,6 +173,11 @@ body[data-error] #container {
 }
 
 .main-textarea {
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
   width: 100%;
   height: 100%;
   resize: none;


### PR DESCRIPTION
Force textbox to take up entire area with crummy position: absolute settings.
