### PR TITLE
Low impact fix for #676, allow basic loading in IE9.

### DIFF
--- a/src/butter.js
+++ b/src/butter.js
@@ -44,24 +44,8 @@
         path = path.join( '/' ) + '/';
 
         if ( !window.require ) {
-          document.write( '<script data-butter-exclude="true" src="' + path + '../external/require/require.js"></' + 'script>' );
+          document.write( '<script data-main="' + path + 'config" data-butter-exclude="true" src="' + path + '../external/require/require.js"></' + 'script>' );
         } //if
-
-        // Set up paths to find scripts.
-        document.write('<script data-butter-exclude="true">' + 
-          '(function(){' + 
-          'var ctx = require.config({ ' + 
-            'baseUrl: "' + path + '",' +
-            'context: "butter",' +
-            'paths: {' +
-              'external: "' + path + '../external",' +
-              'butter: "' + path + '"' +
-              // Paths are relative to baseUrl; Notice the commas!
-            '}' +
-          '});' +
-          'ctx(["main"])' + 
-          '})()' +
-        '</script>');
     }
 
 }());

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the MIT license
+ * If a copy of the MIT license was not distributed with this file, you can
+ * obtain one at http://www.mozillapopcorn.org/butter-license.txt */
+
+define(function( require, exports, module ){
+
+  //Use the global requirejs to create a new context.
+  var ctx = requirejs.config({
+    context: "butter",
+    baseUrl: module.uri.substring(0, module.uri.lastIndexOf('/')),
+    // Paths are relative to the baseUrl
+    paths: {
+      external: "../external"
+    }
+  });
+
+  ctx( [ "main" ] );
+});


### PR DESCRIPTION
This is a quick fix for:
https://webmademovies.lighthouseapp.com/projects/65733/tickets/676-butter-fails-to-load-in-ie9

Note that this just gets the loading to work in IE9. There are other compatibility changes needed. For instance, timeline/module.js uses classList which is not in IE9.
