### PR TITLE
[#744]Track Handles Container Box now in line with the tracks container.

### DIFF
--- a/css/butter.ui.deprecated.css
+++ b/css/butter.ui.deprecated.css
@@ -630,10 +630,10 @@
 
 #butter-timeline .track-handle-container {
   position: absolute;
-  height: 133px;
+  height: 135px;
   width: 105px;
   left: 5px;
-  top: 8px;
+  top: 6px;
   bottom: 18px;
   overflow: hidden;
   box-shadow: 0 1px 0 #737373,inset 0 1px 0 #414141, 0 0 1px #000;
@@ -649,8 +649,7 @@
   width: 110px;
   padding: 5%;
   width: 90%;
-  padding-top: 7px;
-  padding-bottom: 7px;
+  padding-top: 9px;
   padding-bottom: 35px;
 }
 


### PR DESCRIPTION
Basically had to change the top position of the box to be 2 less pixels, compensate and increase the height of it by 2, and then change the padding of the track handles themselves to reposition them.

Also removed an extra declaration of padding-bottom for #butter-timeline .track-handle-container .handle-list since it was being overwritten by the correct one that is there now.
