### PR TITLE
[t710] Media loader disappears

### DIFF
--- a/src/core/media.js
+++ b/src/core/media.js
@@ -76,7 +76,15 @@
                   _popcornWrapper.updateEvent( te[ j ] );
                 }
               }
+              if( _view ){
+                _view.update();
+              }
               _em.dispatch( "mediaready" );
+            },
+            constructing: function(){
+              if( _view ){
+                _view.update();
+              }
             },
             fail: function( e ){
               _em.dispatch( "mediafailed", "error" );

--- a/src/core/popcorn-wrapper.js
+++ b/src/core/popcorn-wrapper.js
@@ -23,6 +23,7 @@ define( [ "core/logger", "core/eventmanager" ], function( Logger, EventManager )
         _logger = new Logger( _id + "::PopcornWrapper" ),
         _popcornEvents = options.popcornEvents || {},
         _onPrepare = options.prepare || function(){},
+        _onConstructing = options.constructing || function(){},
         _onFail = options.fail || function(){},
         _onPlayerTypeRequired = options.playerTypeRequired || function(){},
         _onTimeout = options.timeout || function(){},
@@ -156,6 +157,9 @@ define( [ "core/logger", "core/eventmanager" ], function( Logger, EventManager )
             createPopcorn( generatePopcornString( popcornOptions, url, target, null, callbacks, scripts ) );
             // once popcorn is created, attach listeners to it to detect state
             addPopcornHandlers();
+            if( _onConstructing ){
+              _onConstructing();
+            }
             // wait for the media to become available and notify the user, or timeout
             waitForMedia( _onPrepare, timeoutWrapper );
           }, timeoutWrapper );

--- a/src/ui/page-element.js
+++ b/src/ui/page-element.js
@@ -15,9 +15,10 @@ define( [ "core/logger", "core/eventmanager", "util/dragndrop", "ui/position-tra
         _em = new EventManager( this ),
         _blinkFunction,
         _hilightFunction,
+        _positionTracker,
         _this = this;
 
-    PositionTracker( _element, function( rect ){
+    _positionTracker = PositionTracker( _element, function( rect ){
       _highlightElement.style.left = rect.left + "px";
       _highlightElement.style.top = rect.top + "px";
       _highlightElement.style.width = rect.width + "px";
@@ -38,6 +39,7 @@ define( [ "core/logger", "core/eventmanager", "util/dragndrop", "ui/position-tra
     };
 
     this.destroy = function(){
+      _positionTracker.destroy();
       if( _highlightElement.parentNode ){
         _highlightElement.parentNode.removeChild( _highlightElement );
       } //if

--- a/src/ui/position-tracker.js
+++ b/src/ui/position-tracker.js
@@ -3,8 +3,10 @@ define([], function(){
   var POLL_INTERVAL = 20;
   
   return function( object, movedCallback ){
-    var _rect = {};
-    setInterval( function(){
+    var _rect = {},
+        interval;
+
+    interval = setInterval( function(){
       var newPos = object.getBoundingClientRect();
       if( newPos.left !== _rect.left ||
           newPos.right !== _rect.right ||
@@ -14,6 +16,12 @@ define([], function(){
         movedCallback( _rect );
       }
     }, POLL_INTERVAL );
+
+    return {
+      destroy: function(){
+        clearInterval(interval);
+      }
+    }
   };
 
 });


### PR DESCRIPTION
1. Added constructing event to popcorn-wrapper and media
2. View is updated as several places to reflect different states of media loading
3. PositionTracker can be destroyed properly now, and is.
