### PR TITLE
[t787] Media scrape/export fixes

### DIFF
--- a/src/core/popcorn-wrapper.js
+++ b/src/core/popcorn-wrapper.js
@@ -202,11 +202,22 @@ define( [ "core/logger", "core/eventmanager" ], function( Logger, EventManager )
       if( _mediaType !== "object" && targetElement ) {
         if( [ "VIDEO", "AUDIO" ].indexOf( targetElement.nodeName ) !== -1 ) {
           var parentNode = targetElement.parentNode,
-              newElement = document.createElement( "div" );
+              newElement = document.createElement( "div" ),
+              attributes;
 
           newElement.id = targetElement.id;
-          newElement.style.cssText = getComputedStyle( targetElement ).cssText;
+          attributes = targetElement.attributes;
+          if( attributes ){
+            for(var i = attributes.length - 1; i >= 0; i-- ) {
+              var name = attributes[ i ].nodeName;
+              newElement.setAttribute( name, targetElement.getAttribute( name ) );
+            }
+          }
+          if( targetElement.className ){
+            newElement.className = targetElement.className;
+          }
           parentNode.replaceChild( newElement, targetElement );
+          newElement.setAttribute( "data-butter", "media" );
         }
       }
     }

--- a/src/core/popcorn-wrapper.js
+++ b/src/core/popcorn-wrapper.js
@@ -208,7 +208,7 @@ define( [ "core/logger", "core/eventmanager" ], function( Logger, EventManager )
           newElement.id = targetElement.id;
           attributes = targetElement.attributes;
           if( attributes ){
-            for(var i = attributes.length - 1; i >= 0; i-- ) {
+            for( var i = attributes.length - 1; i >= 0; i-- ) {
               var name = attributes[ i ].nodeName;
               newElement.setAttribute( name, targetElement.getAttribute( name ) );
             }

--- a/src/main.js
+++ b/src/main.js
@@ -497,7 +497,7 @@
             medias = scrapedObject.media;
 
         _page.prepare(function() {
-          var i, j, il, jl, url, oldTarget, oldMedia, mediaPopcornOptions;
+          var i, j, il, jl, url, oldTarget, oldMedia, mediaPopcornOptions, mediaObj;
           for( i = 0, il = targets.length; i < il; ++i ) {
             oldTarget = null;
             if( _targets.length > 0 ){
@@ -519,11 +519,15 @@
             oldMedia = null;
             mediaPopcornOptions = null;
             url = "";
-            if( ["VIDEO", "AUDIO" ].indexOf( medias[ i ].nodeName ) > -1 ) {
-              url = medias[ i ].currentSrc;
-            } else {
-              url = medias[ i ].getAttribute( "data-butter-source" );
+            mediaObj = medias[ i ];
+
+            if( mediaObj.getAttribute( "data-butter-source" ) ){
+              url = mediaObj.getAttribute( "data-butter-source" );
             }
+            else if( ["VIDEO", "AUDIO" ].indexOf( mediaObj.nodeName ) > -1 ) {
+              url = mediaObj.currentSrc;
+            }
+
             if( _media.length > 0 ){
               for( j = 0, jl = _media.length; j < jl; ++j ){
                 if( _media[ j ].id !== medias[ i ].id && _media[ j ].url !== url ){

--- a/src/main.js
+++ b/src/main.js
@@ -524,7 +524,7 @@
             if( mediaObj.getAttribute( "data-butter-source" ) ){
               url = mediaObj.getAttribute( "data-butter-source" );
             }
-            else if( ["VIDEO", "AUDIO" ].indexOf( mediaObj.nodeName ) > -1 ) {
+            else if( [ "VIDEO", "AUDIO" ].indexOf( mediaObj.nodeName ) > -1 ) {
               url = mediaObj.currentSrc;
             }
 

--- a/test/core.js
+++ b/test/core.js
@@ -576,6 +576,21 @@
     });
   });
 
+  test( "Test strange div/video player support", function(){
+    expect( 4 );
+    var el = document.createElement( "video" );
+    el.setAttribute( "data-butter-source", "http://www.youtube.com/watch?v=7glrZ4e4wYU" );
+    el.setAttribute( "data-butter", "media" );
+    el.id = "strange-test-1";
+    document.body.appendChild( el );
+    createButter(function( butter ){
+      ok( butter.media.length > 0 && butter.media[0].url === "http://www.youtube.com/watch?v=7glrZ4e4wYU", "URL match" );
+      ok( document.getElementById( "strange-test-1" ), "New element exists" );
+      equals( document.getElementById( "strange-test-1" ).attributes.length, el.attributes.length, "has same attribute list length" );
+      equals( document.getElementById( "strange-test-1" ).getAttribute( "data-butter" ), "media", "has data-butter attribute" );
+    });
+  });
+
   test( "Popcorn Options", function(){
     expect( 2 );
     createButter(function( butter ) {


### PR DESCRIPTION
1. For media obejcts, use data-butter-source attribute, then revert to currentSrc attrib for html5 media only
2. Copy attributes, class, id individually instead of recreating style and attributes through verbose methods
3. Tests
