### PR TITLE
Allow 'new Function' in jshint, and fix stray (undetected) semi-colon vs...

### DIFF
--- a/src/core/popcorn-wrapper.js
+++ b/src/core/popcorn-wrapper.js
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the MIT license
  * If a copy of the MIT license was not distributed with this file, you can
  * obtain one at http://www.mozillapopcorn.org/butter-license.txt */
+/*jshint evil:true*/
 
 define( [ "core/logger", "core/eventmanager" ], function( Logger, EventManager ) {
 
@@ -348,7 +349,7 @@ define( [ "core/logger", "core/eventmanager" ], function( Logger, EventManager )
      * and insert it as a script in the head if that fails.
      */
     function createPopcorn( popcornString ){
-      var popcornFunction = new Function( "", popcornString );
+      var popcornFunction = new Function( "", popcornString ),
           popcorn = popcornFunction();
       if ( !popcorn ) {
         var popcornScript = document.createElement( "script" );


### PR DESCRIPTION
.... comma in popcorn-wrapper.js

https://webmademovies.lighthouseapp.com/projects/65733/tickets/1145-fix-lint-issue-the-function-constructor-is-eval-in-popcorn-wrapperjs
