### PR TITLE
Make edit source dialog expand if media fails to load [#757]

### DIFF
--- a/src/core/views/media-view.js
+++ b/src/core/views/media-view.js
@@ -77,6 +77,8 @@ define( [ "ui/page-element", "ui/logo-spinner", "util/lang", "ui/widget/textbox"
     media.listen( "mediafailed", function( e ){
       showError( true, "Media failed to load. Check your URL:" );
       changeButton.removeAttribute( "disabled" );
+      _propertiesElement.classList.add( "hold" );
+      //_propertiesElement.classList.add( "butter-media-properties-error" );
       _logoSpinner.stop();
     });
 

--- a/src/core/views/media-view.js
+++ b/src/core/views/media-view.js
@@ -75,7 +75,7 @@ define( [ "ui/page-element", "ui/logo-spinner", "util/lang", "ui/widget/textbox"
     });
 
     media.listen( "mediafailed", function( e ){
-      showError( true, "Media failed to load. Check your URL:" );
+      showError( true, "Media failed to load. Check your URL." );
       changeButton.removeAttribute( "disabled" );
       _propertiesElement.classList.add( "hold" );
       urlTextbox.className += " form-error";

--- a/src/core/views/media-view.js
+++ b/src/core/views/media-view.js
@@ -40,7 +40,7 @@ define( [ "ui/page-element", "ui/logo-spinner", "util/lang", "ui/widget/textbox"
 
     function changeUrl(){
       if(testUrl(urlTextbox.value)){
-          subtitle.className = "form-field-notes form-ok";
+        subtitle.className = "form-field-notes form-ok";
         subtitle.innerHTML = "URL changed.";
         urlTextbox.className = "url form-ok";
         media.url = urlTextbox.value;
@@ -78,7 +78,8 @@ define( [ "ui/page-element", "ui/logo-spinner", "util/lang", "ui/widget/textbox"
       showError( true, "Media failed to load. Check your URL:" );
       changeButton.removeAttribute( "disabled" );
       _propertiesElement.classList.add( "hold" );
-      //_propertiesElement.classList.add( "butter-media-properties-error" );
+      urlTextbox.className += " form-error";
+      subtitle.className += " form-error";
       _logoSpinner.stop();
     });
 


### PR DESCRIPTION
If you use a bad source, and the media fails to load, It will make the edit source dialog open, displaying the error within.
