### PR TITLE
[t1258] load project keeps name/id of old project

### DIFF
--- a/dialogs/load-project.html
+++ b/dialogs/load-project.html
@@ -11,7 +11,10 @@
         var list = document.getElementById( "project-list" );
 
         Dialog.registerActivity( "load", function( e ){
-          Dialog.send( "submit", list.value );
+          Dialog.send( "submit", {
+            id: list.value,
+            name: list.querySelectorAll( 'option' )[ list.selectedIndex ].innerHTML
+          });
         });
 
         Dialog.disableElements( "load", "project-list" );

--- a/src/ui/header.js
+++ b/src/ui/header.js
@@ -273,7 +273,9 @@ define( [ "dialog/iframe-dialog" ], function( IFrameDialog ){
                 },
                 submit: function( e ){
                   dialog.close();
-                  butter.cornfield.load( e.data, function( e ){
+                  var projectName = e.data.name,
+                      projectId = e.data.id;
+                  butter.cornfield.load( projectId, function( e ){
                     if( e.error === "okay" ){
                       var projectData;
                       try{
@@ -285,6 +287,8 @@ define( [ "dialog/iframe-dialog" ], function( IFrameDialog ){
                       }
                       butter.clearProject();
                       butter.importProject( projectData );
+                      butter.project.name = projectName;
+                      butter.project.id = projectId;
                     }
                     else{
                       showErrorDialog( "Your project could not be loaded. Please try another." );


### PR DESCRIPTION
1. Added pass-back of id/name from load-project dialog
2. Load handler in header.js keeps id/name around after submitting projectData to cornfield
3. Re-installs id/name after successful save
