### PR TITLE
Reading the token from window.CSRF_TOKEN instead of parsing

### DIFF
--- a/src/util/xhr.js
+++ b/src/util/xhr.js
@@ -22,21 +22,6 @@
 
   define( [], function() {
 
-    function setCSRFToken() {
-      var element = document.getElementById("csrf_token_id");
-      if ( element ) {
-        csrf_token = element.value;
-      }
-    }
-
-    var csrf_token;
-
-    if ( document.readyState === "complete" ) {
-      setCSRFToken();
-    } else {
-      document.addEventListener( "DOMContentLoaded", setCSRFToken, false );
-    }
-
     var XHR = {
       "get": function(url, callback) {
         var xhr = new XMLHttpRequest();
@@ -50,8 +35,8 @@
         xhr.open("POST", url, true);
         xhr.onreadystatechange = callback;
         xhr.setRequestHeader( "X-Requested-With", "XMLHttpRequest" );
-        if ( csrf_token ) {
-          xhr.setRequestHeader( "X-CSRFToken", csrf_token );
+        if ( window.CSRF_TOKEN ) {
+          xhr.setRequestHeader( "X-CSRFToken", window.CSRF_TOKEN );
         }
         if ( !type ) {
           xhr.setRequestHeader( "Content-Type", "application/x-www-form-urlencoded" );


### PR DESCRIPTION
Bugfix for: https://webmademovies.lighthouseapp.com/projects/65733/tickets/1293-xhr-library-is-not-sending-the-csrf-token#ticket-1293-1
