### PR TITLE
[#1386] Fixed cornfield test failing still when run on node server

### DIFF
--- a/test/cornfield/cornfield.js
+++ b/test/cornfield/cornfield.js
@@ -171,6 +171,7 @@
       if( request.status === 404 ){
         ok( false, "Cornfield server not running on current server, skipping tests." );
       } else {
+        ok( true, "Cornfield server is running on current server. Running Tests." );
         setupCornfieldTests();
       }
       start();


### PR DESCRIPTION
https://webmademovies.lighthouseapp.com/projects/65733-popcorn-maker/tickets/1386-cornfield-test-reports-fail-even-when-running-on-port-8888
