### PR TITLE
T1500

### DIFF
--- a/src/core/views/track-view.js
+++ b/src/core/views/track-view.js
@@ -38,7 +38,7 @@ define( [ "core/logger",
         drop: function( dropped, mousePosition ) {
 
           var draggableType = dropped.getAttribute( "data-butter-draggable-type" );
-          
+
           var start,
               left,
               trackRect = _element.getBoundingClientRect();
@@ -101,7 +101,7 @@ define( [ "core/logger",
           _duration = val;
           resetContainer();
           for( var i=0, l=_trackEvents.length; i<l; ++i ){
-            _trackEvents[ i ].duration = _duration;
+            _trackEvents[ i ].update();
           } //for
         }
       },
@@ -132,7 +132,6 @@ define( [ "core/logger",
       _trackEvents.push( trackEvent.view );
       _trackEventElements.push( trackEvent.view.element );
       trackEvent.view.zoom = _zoom;
-      trackEvent.view.duration = _duration;
       trackEvent.view.parent = _this;
       _this.chain( trackEvent, [
         "trackeventmousedown",

--- a/src/core/views/trackevent-view.js
+++ b/src/core/views/trackevent-view.js
@@ -31,8 +31,8 @@ define( [ "core/logger", "core/eventmanager", "util/dragndrop" ], function( Logg
     } //toggleHandles
 
     function resetContainer(){
-      _element.style.left = ( _start * _zoom ) + "px";
-      _element.style.width = ( ( _end - _start ) * _zoom ) + "px";
+      _element.style.left = _start * _zoom + "px";
+      _element.style.width = ( _end - _start ) * _zoom + "px";
     } //resetContainer
 
     this.setToolTip = function( title ){

--- a/src/core/views/trackevent-view.js
+++ b/src/core/views/trackevent-view.js
@@ -3,7 +3,7 @@
  * obtain one at http://www.mozillapopcorn.org/butter-license.txt */
 
 define( [ "core/logger", "core/eventmanager", "util/dragndrop" ], function( Logger, EventManagerWrapper, DragNDrop ){
-  
+
   var __guid = 0;
 
   return function( trackEvent, type, inputOptions ){
@@ -11,7 +11,6 @@ define( [ "core/logger", "core/eventmanager", "util/dragndrop" ], function( Logg
     var _id = "TrackEventView" + __guid++,
         _element = document.createElement( "div" ),
         _zoom = 1,
-        _duration = 1,
         _type = type,
         _start = inputOptions.start || 0,
         _end = inputOptions.end || _start + 1,
@@ -32,8 +31,8 @@ define( [ "core/logger", "core/eventmanager", "util/dragndrop" ], function( Logg
     } //toggleHandles
 
     function resetContainer(){
-      _element.style.left = ( _start / _duration * _zoom ) + "px";
-      _element.style.width = ( ( _end - _start ) / _duration * _zoom ) + "px";
+      _element.style.left = ( _start * _zoom ) + "px";
+      _element.style.width = ( ( _end - _start ) * _zoom ) + "px";
     } //resetContainer
 
     this.setToolTip = function( title ){
@@ -107,15 +106,6 @@ define( [ "core/logger", "core/eventmanager", "util/dragndrop" ], function( Logg
         },
         set: function( val ){
           _zoom = val;
-          resetContainer();
-        }
-      },
-      duration: {
-        enumerable: true,
-        get: function(){
-          return _element.getBoundingClientRect().width / _zoom;
-        },
-        set: function( val ){
           resetContainer();
         }
       },

--- a/src/timeline/timebar.js
+++ b/src/timeline/timebar.js
@@ -38,7 +38,7 @@ define( [ "util/lang", "./scrubber" ], function( util, Scrubber ) {
         _canvas.width = containerWidth;
       }
 
-      var inc = _tracksContainer.container.scrollWidth / _media.duration,
+      var inc = _tracksContainer.element.firstChild.clientWidth / _media.duration,
           textWidth = context.measureText( util.secondsToSMPTE( 5 ) ).width,
           padding = 20,
           lastPosition = 0,

--- a/src/timeline/track-container.js
+++ b/src/timeline/track-container.js
@@ -132,8 +132,13 @@ function(
 
     _this.snapTo = function( time ){
       var p = time / _media.duration,
-          newScroll = _element.scrollWidth * p;
+          newScroll = _container.clientWidth * p,
+          maxLeft = _container.clientWidth - _element.clientWidth;
       if ( newScroll < _element.scrollLeft || newScroll > _element.scrollLeft + _element.clientWidth ) {
+        if ( newScroll > maxLeft ) {
+          _element.scrollLeft = maxLeft;
+          return;
+        }
         _element.scrollLeft = newScroll;
       }
     };


### PR DESCRIPTION
1. I've added checks to make sure snap to never snaps out of the visible track area, if there happen to be track events that are outside of the video's duration.
2. I found some crufty duration related code in trackevent-view.js, where _duration would always be 1. It was never updated and not needed to correctly render trackevents. I modified the update in track-veiw.js to simply call update on its trackevents, so that the container is reset.
