### PR TITLE
[t1775] init/before/after scripts in export

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "connect-mongo": "0.1.x",
     "stylus": "0.25.x",
     "csslint": "0.9.x",
-    "uglify-js": "1.3.x"
+    "uglify-js": "1.3.x",
+    "html5": "0.3.x"
   },
   "license": "MIT",
   "engine": {

--- a/src/core/popcorn-wrapper.js
+++ b/src/core/popcorn-wrapper.js
@@ -1,3 +1,5 @@
+
+
 /* This Source Code Form is subject to the terms of the MIT license
  * If a copy of the MIT license was not distributed with this file, you can
  * obtain one at http://www.mozillapopcorn.org/butter-license.txt */
@@ -241,6 +243,16 @@ define( [ "core/logger", "core/eventmanager", "util/uri" ], function( Logger, Ev
       }
     }
 
+    /* Determines whether or not `script` is a Function, and attempts to get its src if
+     * it is. Otherwise, return a string equivalent to that passed in.
+     */
+    function scriptToString( script ){
+      if ( typeof script === "function" ) {
+        return "(" + script.toString() + "(popcorn));\n";
+      }
+      return script;
+    }
+
     /* Determine which player is needed (usually based on the result of findMediaType)
      * and create a stringified representation of the Popcorn constructor (usually to
      * insert in a script tag).
@@ -289,7 +301,7 @@ define( [ "core/logger", "core/eventmanager", "util/uri" ], function( Logger, Ev
       }
 
       if( scripts.init ){
-        popcornString += scripts.init + "\n";
+        popcornString += scriptToString( scripts.init ) + "\n";
       }
       if( callbacks.init ){
         popcornString += callbacks.init + "();\n";
@@ -306,7 +318,7 @@ define( [ "core/logger", "core/eventmanager", "util/uri" ], function( Logger, Ev
       }
 
       if( scripts.beforeEvents ){
-        popcornString += scripts.beforeEvents + "\n";
+        popcornString += scriptToString( scripts.beforeEvents ) + "\n";
       }
       if( callbacks.beforeEvents ){
         popcornString += callbacks.beforeEvents + "( popcorn );\n";
@@ -349,7 +361,7 @@ define( [ "core/logger", "core/eventmanager", "util/uri" ], function( Logger, Ev
       }
 
       if( scripts.afterEvents ){
-        popcornString += scripts.afterEvents + "\n";
+        popcornString += scriptToString( scripts.afterEvents ) + "\n";
       }
       if( callbacks.afterEvents ){
         popcornString += callbacks.afterEvents + "( popcorn );\n";

--- a/src/main.js
+++ b/src/main.js
@@ -101,6 +101,10 @@
           _customData = {},
           _defaultPopcornCallbacks = {};
 
+      // Expose popcorn scripts/callbacks to Butter
+      this.popcornScripts = _defaultPopcornScripts;
+      this.popcornCallbacks = _defaultPopcornCallbacks;
+
       // We use the default configuration in src/default-config.json as
       // a base, and override whatever the user provides in the
       // butterOptions.config file.

--- a/test/core.js
+++ b/test/core.js
@@ -929,6 +929,43 @@
     });
   });
 
+  asyncTest( "Inline scripts", 3, function(){
+
+    createButter( function( butter ){
+
+      var theZONE = "";
+
+      function testoTronInit( popcorn ){
+        theZone += "i" + !!popcorn;
+      }
+
+      function testoTronBefore( popcorn ){
+        theZone += "b" + !!popcorn;
+      }
+
+      function testoTronAfter( popcorn ){
+        theZone += "a" + !!popcorn;
+      }
+
+      var m1 = butter.addMedia( { name: "Media 1", target: "audio-test", url: "../external/popcorn-js/test/trailer.ogv" } );
+
+      m1.onReady(function(){
+        butter.popcornScripts.init = testoTronInit;
+        butter.popcornScripts.beforeEvents = testoTronBefore;
+        butter.popcornScripts.afterEvents = testoTronAfter;
+
+        var exported = butter.getHTML();
+        ok( exported.indexOf( "testoTronInit" ) > -1, "init callback is in export script" );
+        ok( exported.indexOf( "testoTronBefore" ) > -1, "before callback is in export script" );
+        ok( exported.indexOf( "testoTronAfter" ) > -1, "after callback is in export script" );
+
+        start();
+      });
+
+    });
+  });
+
+
   module( "Dependency Loader" );
   asyncTest( "Load test script", 3, function(){
 


### PR DESCRIPTION
1. Added support for using functions directly (only works client-side).
2. Added support for #id script insertion in cornfield.
3. Added tests for (1).
4. Exposed scripts/callbacks on Butter objects.
