### PR TITLE
[#1856] Moved play() to after seek event detected

### DIFF
--- a/src/core/media.js
+++ b/src/core/media.js
@@ -63,6 +63,9 @@
               },
               ended: function(){
                 _this.dispatch( "mediaended" );
+              },
+              seeked: function(){
+                _this.dispatch( "mediaseeked" );
               }
             },
             prepare: function(){

--- a/src/timeline/scrubber.js
+++ b/src/timeline/scrubber.js
@@ -29,7 +29,9 @@ define( [], function(){
         _lastTime = -1,
         _lastScroll = _tracksContainer.element.scrollLeft,
         _lastZoom = -1,
-        _lineWidth = 0;
+        _lineWidth = 0,
+        _seekCompleted = false,
+        _seekMouseUp = false;
 
     _container.className = "time-bar-scrubber-container";
     _node.className = "time-bar-scrubber-node";
@@ -98,8 +100,13 @@ define( [], function(){
     hScrollbar.listen( "scroll", setNodePosition );
 
     function onMouseUp( e ){
-      if( _isPlaying || _isScrubbing ){
+      _seekMouseUp = true;
+
+      if( _isPlaying && _seekCompleted ){
         _media.play();
+      }
+
+      if( _isScrubbing ){
         _isScrubbing = false;
       }
 
@@ -163,6 +170,16 @@ define( [], function(){
       setNodePosition();
     } //onMouseMove
 
+    function onSeeked( e ){
+      _seekCompleted = true;
+
+      _media.unlisten( "mediaseeked", onSeeked );
+
+      if( _isPlaying && _seekMouseUp ) {
+        _media.play();
+      }
+    }
+
     function onScrubberMouseDown( e ){
       _mouseDownPos = e.pageX - _node.offsetLeft;
 
@@ -171,10 +188,13 @@ define( [], function(){
         _isScrubbing = true;
       }
 
+      _seekCompleted = _seekMouseUp = false;
+      _media.listen( "mediaseeked", onSeeked );
+
       _node.removeEventListener( "mousedown", onScrubberMouseDown, false );
       window.addEventListener( "mousemove", onMouseMove, false );
       window.addEventListener( "mouseup", onMouseUp, false );
-    } //onMouesDown
+    } //onMouseDown
 
     var onMouseDown = this.onMouseDown = function( e ){
       var pos = e.pageX - _container.getBoundingClientRect().left;


### PR DESCRIPTION
Fix for Lighthouse issue [#1856](https://webmademovies.lighthouseapp.com/projects/65733-popcorn-maker/tickets/1856-media-play-while-scrubbing-breaks-things)

Adds mediaseeked event and uses that event to determine when to play(), instead of just calling play() immediately on mouseup.
