### PR TITLE
[1861] [IE9] Tray doesn't load

### DIFF
--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -44,9 +44,7 @@ define([ 'util/xhr' ], function( XHR ){
           scriptElement.src = url;
           scriptElement.type = "text/javascript";
           document.head.appendChild( scriptElement );
-          scriptElement.onload = function () {
-            callback();
-          }
+          scriptElement.onload = callback;
         }
         else if( callback ){
           callback();

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -44,7 +44,9 @@ define([ 'util/xhr' ], function( XHR ){
           scriptElement.src = url;
           scriptElement.type = "text/javascript";
           document.head.appendChild( scriptElement );
-          scriptElement.onload = scriptElement.onreadystatechange = callback;
+          scriptElement.onload = function () {
+            callback();
+          }
         }
         else if( callback ){
           callback();


### PR DESCRIPTION
Double execution of the callback function was happening in IE9 due to script.onload and script.onreadystatechage. Removed onreadystatechange to fix, 
