### PR TITLE
[t1877] resizing trackevents is visually correct

### DIFF
--- a/src/core/views/trackevent-view.js
+++ b/src/core/views/trackevent-view.js
@@ -21,6 +21,7 @@ define( [ "core/logger", "core/eventmanager", "util/dragndrop",
         _resizable,
         _trackEvent = trackEvent,
         _dragging = false,
+        _padding = 0,
         _this = this;
 
     EventManagerWrapper( _this );
@@ -138,6 +139,15 @@ define( [ "core/logger", "core/eventmanager", "util/dragndrop",
           if( _parent ){
 
             if( _parent.element && _parent.element.parentNode && _parent.element.parentNode.parentNode ){
+
+              // Capture the element's computed style on initialization
+              var elementStyle = getComputedStyle( _element ),
+                  paddingLeft = elementStyle.paddingLeft ? +elementStyle.paddingLeft.substring( 0, elementStyle.paddingLeft.length - 2 ) : 0,
+                  paddingRight = elementStyle.paddingRight ? +elementStyle.paddingRight.substring( 0, elementStyle.paddingRight.length - 2 ) : 0;
+
+              // Store padding values to negate from width calculations
+              _padding = paddingLeft + paddingRight;
+
               _draggable = DragNDrop.draggable( _element, {
                 containment: _parent.element.parentNode,
                 scroll: _parent.element.parentNode.parentNode,
@@ -158,6 +168,7 @@ define( [ "core/logger", "core/eventmanager", "util/dragndrop",
               _resizable = DragNDrop.resizable( _element, {
                 containment: _parent.element.parentNode,
                 scroll: _parent.element.parentNode.parentNode,
+                padding: _padding,
                 stop: movedCallback
               });
 
@@ -187,9 +198,8 @@ define( [ "core/logger", "core/eventmanager", "util/dragndrop",
 
     function movedCallback() {
       _element.style.top = "0px";
-      var rect = _element.getClientRects()[ 0 ];
       _start = _element.offsetLeft / _zoom;
-      _end = _start + rect.width / _zoom;
+      _end = _start + ( _element.offsetWidth - _padding ) / _zoom;
       _trackEvent.update({
         start: _start,
         end: _end

--- a/src/util/dragndrop.js
+++ b/src/util/dragndrop.js
@@ -183,6 +183,7 @@ define([], function(){
         _rightHandle = element.querySelector( ".handle.right-handle" ),
         _onStart = options.start || function(){},
         _onStop = options.stop || function(){},
+        _padding = options.padding || 0,
         _updateInterval = -1,
         _scroll = options.scroll,
         _scrollRect,
@@ -193,7 +194,7 @@ define([], function(){
 
       var originalRect = element.getBoundingClientRect(),
           originalPosition = element.offsetLeft,
-          originalWidth = element.offsetWidth,
+          originalWidth = element.clientWidth,
           mouseDownPosition = e.clientX,
           mousePosition,
           mouseOffset;
@@ -223,7 +224,7 @@ define([], function(){
         }
 
         element.style.left = newX + "px";
-        element.style.width = newW + "px";
+        element.style.width = newW - _padding + "px";
         _elementRect = element.getBoundingClientRect();
       }
 

--- a/src/util/time.js
+++ b/src/util/time.js
@@ -4,7 +4,7 @@
 
 define( [], function(){
 
-  var __timeAccuracy = 3;
+  var __timeAccuracy = 5;
 
   function roundTime( time ){
     return Math.round( time * ( Math.pow( 10, __timeAccuracy ) ) ) / Math.pow( 10, __timeAccuracy );


### PR DESCRIPTION
1. TrackEvent checks and stores padding of its view element.
2. DragNDrop resizable stabilized based on padding.
3. TimeUtil rounding upped to 5 decimal places for better accuracy.
