### PR TITLE
[t1892] removed duplication of track reference

### DIFF
--- a/src/core/media.js
+++ b/src/core/media.js
@@ -143,18 +143,6 @@
         _this.dispatch( "trackeventrequested", e );
       }
 
-      function onTrackEventAdded( e ){
-        var trackEvent = e.data;
-        _popcornWrapper.updateEvent( trackEvent );
-        trackEvent._popcornWrapper = _popcornWrapper;
-      } //onTrackEventAdded
-
-      function onTrackEventRemoved( e ){
-        var trackEvent = e.data;
-        _popcornWrapper.destroyEvent( trackEvent );
-        trackEvent._popcornWrapper = null;
-      } //onTrackEventRemoved
-
       this.addTrack = function ( track ) {
         if ( !( track instanceof Track ) ) {
           track = new Track( track );
@@ -170,8 +158,6 @@
           "trackeventselected",
           "trackeventdeselected"
         ]);
-        track.listen( "trackeventadded", onTrackEventAdded );
-        track.listen( "trackeventremoved", onTrackEventRemoved );
         _this.dispatch( "trackadded", track );
         track.setPopcornWrapper( _popcornWrapper );
         var trackEvents = track.trackEvents;
@@ -209,8 +195,6 @@
             "trackeventdeselected"
           ]);
           track.setPopcornWrapper( null );
-          track.unlisten( "trackeventadded", onTrackEventAdded );
-          track.unlisten( "trackeventremoved", onTrackEventRemoved );
           _this.dispatch( "trackremoved", track );
           track._media = null;
           return track;

--- a/src/core/trackevent.js
+++ b/src/core/trackevent.js
@@ -40,7 +40,7 @@ define( [
    *
    * @param {Object} options: Options for initialization. Can contain the properties type, name, and popcornOptions. If the popcornOptions property is specified, its contents will be used to initialize the plugin instance associated with this TrackEvent.
    */
-  var TrackEvent = function ( options ) {
+  var TrackEvent = function ( options, track, popcornWrapper ) {
 
     options = options || {};
 
@@ -48,14 +48,14 @@ define( [
         _id = "TrackEvent" + __guid++,
         _name = options.name || _id,
         _logger = new Logger( _id ),
-        _track,
+        _track = track,
         _type = options.type + "",
         _popcornOptions = options.popcornOptions || {
           start: 0,
           end: 1
         },
         _view = new TrackEventView( this, _type, _popcornOptions ),
-        _popcornWrapper = null,
+        _popcornWrapper = popcornWrapper,
         _selected = false;
 
     EventManagerWrapper( _this );
@@ -235,24 +235,29 @@ define( [
       _this.update( _popcornOptions );
     }; //moveFrameRight
 
+    /**
+     * Member: unbind
+     *
+     * Kills references to popcornWrapper and track which are necessary to function. TrackEvent becomes
+     * a husk for popcorn data at this point.
+     */
+    this.unbind = function() {
+      _popcornWrapper.destroyEvent( _this );
+      _popcornWrapper = null;
+      _track = null;
+    };
+
     Object.defineProperties( this, {
 
       /**
-       * Property: _track
+       * Property: track
        *
-       * Specifies the track on which this TrackEvent currently sites. When set, an update occurs.
-       * @malleable: Yes, but not recommended. Butter will manipulate this value automatically. Other uses may yield unexpected results.
+       * Specifies the track on which this TrackEvent currently sites.
        */
-      _track: {
+      track: {
         enumerable: true,
         get: function(){
           return _track;
-        },
-        set: function( val ){
-          _track = val;
-          if ( _track ) {
-            _this.update( _popcornOptions );
-          }
         }
       },
 

--- a/src/core/views/trackevent-view.js
+++ b/src/core/views/trackevent-view.js
@@ -27,10 +27,12 @@ define( [ "core/logger", "core/eventmanager", "util/dragndrop",
 
     EventManagerWrapper( _this );
 
-    function toggleHandles( state ){
-      _handles[ 0 ].style.visibility = state ? "visible" : "hidden";
-      _handles[ 1 ].style.visibility = state ? "visible" : "hidden";
-    } //toggleHandles
+    function toggleHandles( state ) {
+      if ( _parent ) {
+        _handles[ 0 ].style.visibility = state ? "visible" : "hidden";
+        _handles[ 1 ].style.visibility = state ? "visible" : "hidden";
+      }
+    }
 
     function resetContainer(){
       _element.style.left = _start * _zoom + "px";

--- a/src/main.js
+++ b/src/main.js
@@ -225,6 +225,35 @@
         });
       }
 
+      function onTrackEventSelected( e ) {
+        _selectedEvents.push( e.target );
+      }
+
+      function onTrackEventDeSelected( e ) {
+        var trackEvent = e.target,
+            idx = _selectedEvents.indexOf( trackEvent );
+        if ( idx > -1 ) {
+          _selectedEvents.splice( idx, 1 );
+        }
+      }
+
+      function onTrackEventRemoved( e ) {
+        var trackEvent = e.data,
+            idx = _selectedEvents.indexOf( trackEvent );
+        if ( idx > -1 ) {
+          _selectedEvents.splice( idx, 1 );
+        }
+      }
+
+      this.deselectAllTrackEvents = function() {
+        // selectedEvents' length will change as each trackevent's selected property
+        // is set to false, so use a while loop here to loop through the continually
+        // shrinking selectedEvents array.
+        while ( _selectedEvents.length ) {
+          _selectedEvents[ 0 ].selected = false;
+        }
+      };
+
        /****************************************************************
        * Target methods
        ****************************************************************/
@@ -414,6 +443,10 @@
           } //for
         } //if
 
+        media.listen( "trackeventremoved", onTrackEventRemoved );
+        media.listen( "trackeventselected", onTrackEventSelected );
+        media.listen( "trackeventdeselected", onTrackEventDeSelected );
+
         media.listen( "trackeventrequested", mediaTrackEventRequested );
         media.listen( "mediaplayertyperequired", mediaPlayerTypeRequired );
 
@@ -451,6 +484,10 @@
           if ( media === _currentMedia ) {
             _currentMedia = undefined;
           } //if
+
+          media.unlisten( "trackeventremoved", onTrackEventRemoved );
+          media.unlisten( "trackeventselected", onTrackEventSelected );
+          media.unlisten( "trackeventdeselected", onTrackEventDeSelected );
 
           media.unlisten( "trackeventrequested", mediaTrackEventRequested );
           media.unlisten( "mediaplayertyperequired", mediaPlayerTypeRequired );
@@ -578,9 +615,6 @@
         selectedEvents: {
           get: function() {
             return _selectedEvents;
-          },
-          set: function(selectedEvents) {
-            _selectedEvents = selectedEvents;
           },
           enumerable: true
         },

--- a/src/timeline/media.js
+++ b/src/timeline/media.js
@@ -115,10 +115,6 @@ define( [ "core/trackevent", "core/track", "core/eventmanager",
             tracks[ t ].deselectEvents( trackEvent );
           }
         }
-        butter.selectedEvents = [ trackEvent ];
-      }
-      else {
-        butter.selectedEvents.push( trackEvent );
       }
     }
 

--- a/src/timeline/track-container.js
+++ b/src/timeline/track-container.js
@@ -20,7 +20,7 @@ define( [ "core/logger", "util/dragndrop" ],
     var _droppable;
 
     _container.addEventListener( "mousedown", function( e ) {
-      _this.deselectOthers();
+      butter.deselectAllTrackEvents();
     }, false );
 
     _droppable = DragNDrop.droppable( _element, {
@@ -54,14 +54,6 @@ define( [ "core/logger", "util/dragndrop" ],
           _container.insertBefore( trackElement, _container.childNodes[ i + 1 ] );
         }
       }
-    };
-
-    this.deselectOthers = function() {
-      for ( var i = 0; i < butter.selectedEvents.length; i++ ) {
-        butter.selectedEvents[ i ].selected = false;
-      }
-      butter.selectedEvents = [];
-      return _this;
     };
 
     function resetContainer() {

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -203,14 +203,17 @@ define( [ "core/eventmanager", "./toggler",
       38: function( e ) { // up key
         var track,
             trackEvent,
-            nextTrack;
+            nextTrack,
 
-        if ( butter.selectedEvents.length ) {
+            //copy this selectedEvents because it will change inside loop
+            selectedEvents = butter.selectedEvents.slice();
+
+        if ( selectedEvents.length ) {
           e.preventDefault();
         }
 
-        for( var i = 0, seLength = butter.selectedEvents.length; i < seLength; i++ ) {
-          trackEvent = butter.selectedEvents[ i ];
+        for( var i = 0, seLength = selectedEvents.length; i < seLength; i++ ) {
+          trackEvent = selectedEvents[ i ];
           track = trackEvent.track;
           nextTrack = orderedTracks[ orderedTracks.indexOf( track ) - 1 ];
           if( nextTrack ) {
@@ -233,14 +236,17 @@ define( [ "core/eventmanager", "./toggler",
       40: function( e ) { // down key
         var track,
             trackEvent,
-            nextTrack;
+            nextTrack,
 
-        if ( butter.selectedEvents.length ) {
+            //copy this selectedEvents because it will change inside loop
+            selectedEvents = butter.selectedEvents.slice();
+
+        if ( selectedEvents.length ) {
           e.preventDefault();
         }
 
-        for( var i = 0, seLength = butter.selectedEvents.length; i < seLength; i++ ) {
-          trackEvent = butter.selectedEvents[ i ];
+        for( var i = 0, seLength = selectedEvents.length; i < seLength; i++ ) {
+          trackEvent = selectedEvents[ i ];
           track = trackEvent.track;
           nextTrack = orderedTracks[ orderedTracks.indexOf( track ) + 1 ];
           if( nextTrack ) {
@@ -250,10 +256,7 @@ define( [ "core/eventmanager", "./toggler",
         } // for
       }, // down key
       27: function( e ) { // esc key
-        for( var i = 0; i < butter.selectedEvents.length; i++ ) {
-          butter.selectedEvents[ i ].selected = false;
-        } // for
-        butter.selectedEvents = [];
+        butter.deselectAllTrackEvents();
       }, // esc key
       8: function( e ) { // del key
         if( butter.selectedEvents.length ) {
@@ -261,7 +264,6 @@ define( [ "core/eventmanager", "./toggler",
           for( var i = 0; i < butter.selectedEvents.length; i++ ) {
             butter.selectedEvents[ i ].track.removeTrackEvent( butter.selectedEvents[ i ] );
           } // for
-          butter.selectedEvents = [];
         } // if
       }, // del key
       9: function( e ) { // tab key
@@ -279,12 +281,8 @@ define( [ "core/eventmanager", "./toggler",
               index = orderedTrackEvents.length - 1;
             } // if
           } // if
-          for( var i = 0; i < butter.selectedEvents.length; i++ ) {
-            butter.selectedEvents[ i ].selected = false;
-          } // for
-          butter.selectedEvents = [];
+          butter.deselectAllTrackEvents();
           orderedTrackEvents[ index ].selected = true;
-          butter.selectedEvents.push( orderedTrackEvents[ index ] );
         } // if
       } // tab key
     };


### PR DESCRIPTION
1. TrackEvents can be created/copied, not re-referenced.
2. Fixed selectedEvents so that it is affected in one place.
3. Tighter property access.
