### PR TITLE
Bug 1859 - Change default google maps zoom to be higher

### DIFF
--- a/editors/googlemap-editor.js
+++ b/editors/googlemap-editor.js
@@ -206,7 +206,7 @@ document.addEventListener( "DOMContentLoaded", function domReady() {
         }
 
         elements.type.value = elements.type.value || "ROADMAP";
-        trackEvent.zoom = typeof trackEvent.zoom === "number" ? trackEvent.zoom : 1;
+        trackEvent.zoom = typeof trackEvent.zoom === "number" ? trackEvent.zoom : 10;
 
         if ( stamenTypes.indexOf( trackEvent.type ) !== -1 ) {
           layer = trackEvent.type.toLowerCase();


### PR DESCRIPTION
This changes the submodule to point at a commit where the default zoom is 10 instead of 1.
