### PR TITLE
[1863] Added basic double click functionality to plugin list

### DIFF
--- a/src/plugin/plugin-list.js
+++ b/src/plugin/plugin-list.js
@@ -44,6 +44,15 @@ define( [ "util/dragndrop", "util/lang", "editor/editor", "text!layouts/plugin-l
         }
       });
 
+      element.addEventListener("dblclick", function( e ) {
+        var media = butter.currentMedia;
+         media.tracks[0].view.dispatch( "plugindropped", {
+            start: media.currentTime,
+            track: media.tracks[0],
+            type: element.getAttribute( "data-popcorn-plugin-type" )
+          });
+      }, false );
+
       if ( iconImg ) {
         icon.style.backgroundImage = "url('" + iconImg.src + "')";
       }

--- a/src/plugin/plugin-list.js
+++ b/src/plugin/plugin-list.js
@@ -44,11 +44,11 @@ define( [ "util/dragndrop", "util/lang", "editor/editor", "text!layouts/plugin-l
         }
       });
 
-      element.addEventListener("dblclick", function( e ) {
+      element.addEventListener( "dblclick", function( e ) {
         var media = butter.currentMedia;
          media.tracks[0].view.dispatch( "plugindropped", {
             start: media.currentTime,
-            track: media.tracks[0],
+            track: media.tracks[ 0 ],
             type: element.getAttribute( "data-popcorn-plugin-type" )
           });
       }, false );


### PR DESCRIPTION
Double clicking a plugin will place the respective event to the left of the scrubber. 
