### PR TITLE
[IE9] Fixed "invalid argument" error

### DIFF
--- a/src/editor/trackevent-editor.js
+++ b/src/editor/trackevent-editor.js
@@ -348,8 +348,12 @@ define( [ "util/lang", "util/keys", "./base-editor",
           }
           editorElement.placeholder = editorElement.value = data;
         }
-        editorElement.type = manifestEntry.type;
-
+        try {
+          editorElement.type = manifestEntry.type;
+        }
+        catch ( e ) {
+          // Suppress IE9 errors
+        }
         // data-manifest-key is used to update this property later on
         editorElement.setAttribute( "data-manifest-key", name );
 


### PR DESCRIPTION
IE9 doesn't automatically default to the "text" type when the types are mismatching so it had to be wrapped in a try/catch block to force it to "text".
