### PR TITLE
[#2071] [IE9] Transparent gradients are not supported

### DIFF
--- a/css/super-scrollbar.less
+++ b/css/super-scrollbar.less
@@ -13,7 +13,7 @@
 }
 
 #butter-super-scrollbar-viewport {
-  .gradient( "vertical", fade( #FFF, 20% ), fade( #FFF, 7% ) );
+  .gradient( "vertical", fade( #FFF, 20% ), fade( #FFF, 7% ), true );
   border: 3px solid #FFFFFF;
   box-shadow: 0 1px 2px 1px rgba(0, 0, 0, 0.5) inset;
   cursor: move;


### PR DESCRIPTION
Used the mixin that will cause IE9 to fallback on a solid colour. 
