### PR TITLE
[#2258] Fix Timestamping issues for start/end in Chrome

### DIFF
--- a/src/layouts/trackevent-editor-defaults.html
+++ b/src/layouts/trackevent-editor-defaults.html
@@ -50,12 +50,12 @@
 <fieldset class="butter-form-inline form-half start-end">
   <div class="butter-form-append">
     <label class="property-name">Start</label>
-    <input type="number" class="value" data-manifest-key="start">
+    <input type="text" class="value" data-manifest-key="start">
     <span class="butter-unit">seconds</span>
   </div>
   <div class="butter-form-append">
     <label class="property-name">End</label>
-    <input type="number" class="value" data-manifest-key="end">
+    <input type="text" class="value" data-manifest-key="end">
     <span class="butter-unit">seconds</span>
   </div>
 </fieldset>


### PR DESCRIPTION
https://webmademovies.lighthouseapp.com/projects/65733/tickets/2258-regression-1808-timestamp-formatting-isnt-working-in-chrome#ticket-2258-1
