### PR TITLE
[#2199] Pressing delete while a trackevent is selected now closes the open editor and then reopens the plugin list

### DIFF
--- a/src/editor/base-editor.js
+++ b/src/editor/base-editor.js
@@ -74,7 +74,7 @@ define( [ "core/eventmanager", "util/scrollbars", "ui/widget/tooltip" ],
       if ( events.close ) {
         events.close.apply( extendObject, arguments );
       }
-      
+
       extendObject.dispatch( "closed" );
     };
 

--- a/src/editor/module.js
+++ b/src/editor/module.js
@@ -72,6 +72,18 @@ define( [ "core/eventmanager", "core/trackevent", "./editor",
     };
 
     /**
+     * Member: closeEditor
+     *
+     * Closes the currently opened editor and opens the default one in it's place
+     *
+     */
+    _this.closeEditor = function() {
+      _currentEditor.close();
+      _currentEditor = null;
+      _this.openEditor( DEFAULT_EDITOR_NAME );
+    };
+
+    /**
      * Member: editTrackEvent
      *
      * Open the editor corresponding to the type of the given TrackEvent
@@ -184,7 +196,7 @@ define( [ "core/eventmanager", "core/trackevent", "./editor",
           butter.loader.load( editorsToLoad, function() {
             Editor.loadUrlSpecifiedLayouts( onModuleReady, butter.config.value( "baseDir" ) );
           }, function( e ) {
-            _logger.log( "Couldn't load editor " + e.srcElement.src );
+            _logger.log( "Couldn't load editor " + e.target.src );
             
             if ( ++editorsLoaded === editorsToLoad.length ) {
               onModuleReady();
@@ -201,6 +213,14 @@ define( [ "core/eventmanager", "core/trackevent", "./editor",
       }
     };
 
+    Object.defineProperties( _this, {
+      currentEditor: {
+        enumerable: true,
+        get: function() {
+          return _currentEditor;
+        }
+      }
+    });
   }
 
   this.register = Editor.register;

--- a/src/editor/trackevent-editor.js
+++ b/src/editor/trackevent-editor.js
@@ -33,7 +33,8 @@ define([ "util/lang", "util/keys", "util/time", "./base-editor",
    */
   return function( extendObject, butter, rootElement, events ) {
     // Wedge a check for scrollbars into the open event if it exists
-    var oldOpenEvent = events.open;
+    var _oldOpenEvent = events.open,
+        _trackEvent;
 
     events.open = function( parentElement, trackEvent ) {
       var basicButton = rootElement.querySelector( ".basic-tab" ),
@@ -42,8 +43,10 @@ define([ "util/lang", "util/keys", "util/time", "./base-editor",
           advancedTab = rootElement.querySelector( ".advanced-options" ),
           wrapper = rootElement.querySelector( ".scrollbar-outer" );
 
-      if ( oldOpenEvent ) {
-        oldOpenEvent.apply( this, arguments );
+      _trackEvent = trackEvent;
+
+      if ( _oldOpenEvent ) {
+        _oldOpenEvent.apply( this, arguments );
 
         // Code for handling basic/advanced options tabs are going to be the same. If the user defined these buttons
         // handle it for them here rather than force them to write the code in their editor
@@ -584,6 +587,26 @@ define([ "util/lang", "util/keys", "util/time", "./base-editor",
         }
       }
     };
+
+    extendObject.getTrackEvent = function() {
+      return _trackEvent;
+    };
+
+    butter.listen( "trackeventremoved", function( e ) {
+
+      var currentTrackEvent,
+          currentEditor = butter.editor.currentEditor;
+
+      // Means the current editor is a track event editor
+      if ( currentEditor.getTrackEvent ) {
+
+        currentTrackEvent = currentEditor.getTrackEvent();
+        // Ensure event being deleted matches the one currently being used by the editor
+        if ( e.data.id === currentTrackEvent.id ) {
+          butter.editor.closeEditor();
+        }
+      }
+    });
 
   };
 


### PR DESCRIPTION
https://webmademovies.lighthouseapp.com/projects/65733/tickets/2199-when-a-track-event-is-deleted-its-editor-should-be-closed
