### PR TITLE
[#2275] Font sizes were being inherited differently between firefox/chrome with iframe textarea

### DIFF
--- a/css/embed.less
+++ b/css/embed.less
@@ -345,6 +345,8 @@ body {
 
   .share-options input, 
   .share-options textarea {
+    font-size: 0.6em;
+    resize: none;
     width: 70%;
     padding: 10px;
     float: left;

--- a/css/embed.less
+++ b/css/embed.less
@@ -360,7 +360,7 @@ body {
   } 
 
   .share-options textarea {
-    height: 70px;
+    height: 90px;
     font-family: menlo, monospace;
   }
   
@@ -543,7 +543,7 @@ body {
       }
 
       textarea {
-        height: 30px;
+        height: 110px;
         width: 70%;
         min-width: 0;
       }
@@ -562,8 +562,7 @@ body {
 
     .share-size {
       float: none;
-      margin-left: 20%;
-      margin-top: 60px;
+      margin-left: 97%;
       width: 100%;
 
       .size-options {
@@ -641,7 +640,7 @@ body {
       }
 
       textarea {
-        height: 10px;
+        height: 90px;
         width: 70%;
         min-width: 0;
       }
@@ -660,7 +659,8 @@ body {
       .share-size {
         float: none;
         width: 100%;
-        margin-top: 40px;
+        margin-top: 115px;
+        margin-left: 20%;
       }
 
     }

--- a/css/embed.less
+++ b/css/embed.less
@@ -345,7 +345,7 @@ body {
 
   .share-options input, 
   .share-options textarea {
-    font-size: 0.6em;
+    font-size: 12px;
     resize: none;
     width: 70%;
     padding: 10px;


### PR DESCRIPTION
https://webmademovies.lighthouseapp.com/projects/65733/tickets/2275-embed-iframe-textarea-too-small-font-too-large
