### PR TITLE
[#2032]

### DIFF
--- a/src/util/keys.js
+++ b/src/util/keys.js
@@ -4,6 +4,7 @@ define( [], function() {
 
     DELETE:     8,
     TAB:        9,
+    ENTER:      13,
 
     ENTER:      13,
 


### PR DESCRIPTION
1. Make enter update a track event.
2. Enter also blurs the input element.
3. Make all input events use a single update function, minimizing code
4. Use an ignoreBlur flag to stop double updating of trackEvents. required wrapping in a closure to capture scope.

Lighthouse ticket: https://webmademovies.lighthouseapp.com/projects/65733-popcorn-maker/tickets/2032-pressing-start-on-wikipedia-article-input-should-update-track-event#ticket-2032-2
