### PR TITLE
[#2320] assign default bounds earlier, to ensure that IE9 doesn't access...

### DIFF
--- a/src/timeline/media.js
+++ b/src/timeline/media.js
@@ -15,7 +15,7 @@ define( [ "core/trackevent", "core/track", "core/eventmanager",
 
   function MediaInstance( butter, media ) {
 
-    var _bounds;
+    var _bounds = DEFAULT_BOUNDS;
 
     function setContainerBounds( left, right ) {
       if ( _bounds[0] !== left || _bounds[1] !== right ) {


### PR DESCRIPTION
... them before they're assigned.

Lighthouse Ticket: https://webmademovies.lighthouseapp.com/projects/65733/tickets/2320-_bounds-undefined-in-ie9-on-page-load
