### PR TITLE
[#2363] Use <input type=color> if specified. Still allow Hex/Text input for colors in browsers without support

### DIFF
--- a/src/editor/trackevent-editor.js
+++ b/src/editor/trackevent-editor.js
@@ -281,7 +281,7 @@ define([ "util/lang", "util/keys", "util/time", "./base-editor",
         }
       }, false );
 
-      if ( element.type === "number" ) {
+      if ( element.type !== "text" ) {
         element.addEventListener( "change", function( e ) {
           var updateOptions = {};
           updateOptions[ propertyName ] = element.value;

--- a/templates/assets/plugins/popup/popcorn.popup.js
+++ b/templates/assets/plugins/popup/popcorn.popup.js
@@ -194,7 +194,7 @@
         },
         fontColor: {
           elem: "input",
-          type: "text",
+          type: "color",
           label: "Font",
           "default": "#668B8B",
           group: "advanced"

--- a/templates/assets/plugins/text/popcorn.text.js
+++ b/templates/assets/plugins/text/popcorn.text.js
@@ -17,10 +17,6 @@
     return Math.max( Math.min( value || 0, maxWidth ), minWidth );
   }
 
-  function validateHexColor( color ) {
-    return color.match ? color.match( /^#(?:[0-9a-fA-F]{3}){1,2}$/ ) : false;
-  }
-
   // From humph's text plugin
   var escapeMap = {
     "&": "&amp;",
@@ -101,7 +97,7 @@
         },
         fontColor: {
           elem: "input",
-          type: "text",
+          type: "color",
           label: "Font Colour",
           "default": DEFAULT_FONT_COLOR,
           group: "advanced"
@@ -173,7 +169,7 @@
       container.appendChild( innerContainer );
       target.appendChild( container );
 
-      options.fontColor = options.fontColor && validateHexColor( options.fontColor ) || DEFAULT_FONT_COLOR;
+      innerContainer.style.color = options.fontColor || DEFAULT_FONT_COLOR;
       innerContainer.style.fontStyle = fontDecorations.italics ? "italic" : "normal";
       innerContainer.style.textDecoration = fontDecorations.underline ? "underline" : "none";
       innerContainer.style.fontSize = options.fontSize ? normalize( options.fontSize, 8, 200 ) + "px" : "24px";


### PR DESCRIPTION
https://webmademovies.lighthouseapp.com/projects/65733/tickets/2363-selecting-font-colour-doesnt-work
