### PR TITLE
[t1998] fixed overlap when dropping TE on media

### DIFF
--- a/src/core/media.js
+++ b/src/core/media.js
@@ -347,6 +347,15 @@
         return null;
       };
 
+      this.findNextAvailableTrackFromTimes = function( start, end ) {
+        for ( var i = 0, l = _orderedTracks.length; i < l; ++i ) {
+          if ( !_orderedTracks[ i ].findOverlappingTrackEvent( start, end ) ) {
+            return _orderedTracks[ i ];
+          }
+        }
+        return null;
+      };
+
       Object.defineProperties( this, {
         ended: {
           enumerable: true,

--- a/src/core/track.js
+++ b/src/core/track.js
@@ -198,6 +198,21 @@ define( [ "./eventmanager", "./trackevent", "./views/track-view" ],
       }
     };
 
+    this.findOverlappingTrackEvent = function( start, end ) {
+      var trackEvent, popcornOptions;
+
+      // loop over all the trackevents for this track and see if we overlap
+      for ( var i = 0, l = _trackEvents.length; i < l; i++ ) {
+        trackEvent = _trackEvents[ i ];
+        popcornOptions = trackEvent.popcornOptions;
+        // if a trackevent overlaps and it's not a ghost...
+        if ( !trackEvent.view.isGhost && !( start > popcornOptions.end || end < popcornOptions.start ) ) {
+          return trackEvent;
+        }
+      }
+      return null;
+    };
+
     this.deselectEvents = function( except ){
       for( var i=0, l=_trackEvents.length; i<l; ++i ){
         if( _trackEvents[ i ] !== except ){

--- a/src/main.js
+++ b/src/main.js
@@ -121,35 +121,37 @@
         return _currentMedia.getManifest( name );
       }; //getManifest
 
-      function trackEventRequested( element, media, target ){
+      function trackEventRequested( element, media, target ) {
         var track,
             type = element.getAttribute( "data-popcorn-plugin-type" ),
             start = media.currentTime,
             end;
 
-        if( start > media.duration ){
+        if ( start > media.duration ) {
           start = media.duration - _defaultTrackeventDuration;
         }
 
-        if( start < 0 ){
+        if ( start < 0 ) {
           start = 0;
         }
 
         end = start + _defaultTrackeventDuration;
 
-        if( end > media.duration ){
+        if ( end > media.duration ) {
           end = media.duration;
         }
 
-        if( !type ){
+        if ( !type ) {
           _logger.log( "Invalid trackevent type requested." );
           return;
-        } //if
+        }
 
-        if( media.tracks.length === 0 ){
+        if ( media.tracks.length === 0 ) {
           media.addTrack();
-        } //if
-        track = media.tracks[ 0 ];
+        }
+
+        track = media.findNextAvailableTrackFromTimes( start, end ) || media.addTrack();
+
         var trackEvent = track.addTrackEvent({
           type: type,
           popcornOptions: {
@@ -166,8 +168,8 @@
         return trackEvent;
       }
 
-      function targetTrackEventRequested( e ){
-        if( _currentMedia ){
+      function targetTrackEventRequested( e ) {
+        if ( _currentMedia ) {
           var trackEvent = trackEventRequested( e.data.element, _currentMedia, e.target.elementID );
           _this.dispatch( "trackeventcreated", {
             trackEvent: trackEvent,
@@ -176,8 +178,8 @@
         }
         else {
           _logger.log( "Warning: No media to add dropped trackevent." );
-        } //if
-      } //targetTrackEventRequested
+        }
+      }
 
       function mediaPlayerTypeRequired( e ){
         _page.addPlayerType( e.data );


### PR DESCRIPTION
1. Style fixes.
2. Time-based implementation of findOverlappingTrackEvent in src/core/track (mirrors src/core/track-view impl).
3. Wrote findNextAvailableTrackFromTimes in src/core/media to find an acceptable track candidate.
4. trackeventrequested uses findNextAvailableTrackFromTimes instead of just using the first track.
