### PR TITLE
[#2416] double click to add event (was) broken

### DIFF
--- a/src/plugin/plugin-list.js
+++ b/src/plugin/plugin-list.js
@@ -45,11 +45,13 @@ define( [ "util/dragndrop", "util/lang", "editor/editor", "text!layouts/plugin-l
         }
       });
 
-      // request a new trackEvent on the currentMedia
+      // request a new trackEvent on the first Target
       element.addEventListener( "dblclick", function() {
-        butter.targets[ 0 ].dispatch( "trackeventrequested", {
-          element: element
-        });
+        if ( butter.targets[ 0 ] ) {
+          butter.targets[ 0 ].dispatch( "trackeventrequested", {
+            element: element
+          });
+        }
       }, false );
 
       if ( iconImg ) {

--- a/src/plugin/plugin-list.js
+++ b/src/plugin/plugin-list.js
@@ -47,7 +47,9 @@ define( [ "util/dragndrop", "util/lang", "editor/editor", "text!layouts/plugin-l
 
       // request a new trackEvent on the currentMedia
       element.addEventListener( "dblclick", function() {
-        butter.currentMedia.dispatch( "trackeventrequested", element );
+        butter.targets[ 0 ].dispatch( "trackeventrequested", {
+          element: element
+        });
       }, false );
 
       if ( iconImg ) {

--- a/src/timeline/media.js
+++ b/src/timeline/media.js
@@ -88,9 +88,6 @@ define( [ "core/trackevent", "core/track", "core/eventmanager",
           target.view.blink();
         }
       }
-      else {
-        _media.view.blink();
-      }
     }
 
     function onTrackEventMouseOver( e ){


### PR DESCRIPTION
1. Dispatch trackeventrequested on the first target, not on the media
2. Remove dead call to _media.view.blink()

Lighthouse ticket: https://webmademovies.lighthouseapp.com/projects/65733/tickets/2416
