### PR TITLE
[t2353] initial framebusting protection approach

### DIFF
--- a/css/editors.less
+++ b/css/editors.less
@@ -256,13 +256,20 @@
 
 .butter-form {
 
-// Fieldset
+  // Container building blocks
   .trackevent-property,
+  .trackevent-warning,
   fieldset {
     border: none;
     margin: 10px 20px;
     padding: 0;
     .clearfix();
+  }
+
+  .trackevent-warning {
+    background: darken( @baseLight, 10% );
+    padding: 10px;
+    border-radius: 5px;
   }
 
   // Label

--- a/src/editor/default.js
+++ b/src/editor/default.js
@@ -14,14 +14,18 @@ define( [ "text!./default.html", "editor/editor", "util/lang" ],
    * @param {Butter} butter: An instance of Butter
    * @param {TrackEvent} TrackEvent: The TrackEvent to edit
    */
-  Editor.register( "default", LAYOUT_SRC, function( rootElement, butter, compiledLayout ) {
+  function DefaultEditor( rootElement, butter, compiledLayout, events ) {
 
     var _this = this;
+
+    events = events || {};
 
     var _rootElement = rootElement,
         _trackEvent,
         _targets = [ butter.currentMedia ].concat( butter.targets ),
-        _messageContainer = _rootElement.querySelector( "div.error-message" );
+        _messageContainer = _rootElement.querySelector( "div.error-message" ),
+        _oldOpenEvent = events.open,
+        _oldCloseEvent = events.close;
 
     /**
      * Member: setErrorState
@@ -51,63 +55,69 @@ define( [ "text!./default.html", "editor/editor", "util/lang" ],
     }
 
     // Extend this object to become a TrackEventEditor
-    Editor.TrackEventEditor.extend( _this, butter, rootElement, {
-      open: function ( parentElement, trackEvent ) {
-        var targetList,
-            optionsContainer = _rootElement.querySelector( ".editor-options" ),
-            selectElement;
+    events.open = function ( parentElement, trackEvent ) {
+      var targetList,
+          optionsContainer = _rootElement.querySelector( ".editor-options" ),
+          selectElement;
 
-        _this.applyExtraHeadTags( compiledLayout );
+      _this.applyExtraHeadTags( compiledLayout );
 
-        _trackEvent = trackEvent;
+      _trackEvent = trackEvent;
 
-        optionsContainer.appendChild( _this.createStartEndInputs( trackEvent, updateTrackEvent ) );
+      optionsContainer.appendChild( _this.createStartEndInputs( trackEvent, updateTrackEvent ) );
 
-        _this.createPropertiesFromManifest({
-          trackEvent: trackEvent,
-          callback: function( elementType, element, trackEvent, name ) {
-            if ( elementType === "select" ) {
-              _this.attachSelectChangeHandler( element, trackEvent, name, updateTrackEvent );
+      _this.createPropertiesFromManifest({
+        trackEvent: trackEvent,
+        callback: function( elementType, element, trackEvent, name ) {
+          if ( elementType === "select" ) {
+            _this.attachSelectChangeHandler( element, trackEvent, name, updateTrackEvent );
+          }
+          else {
+            if ( element.type === "checkbox" ) {
+              _this.attachCheckboxChangeHandler( element, trackEvent, name, updateTrackEvent );
             }
             else {
-              if ( element.type === "checkbox" ) {
-                _this.attachCheckboxChangeHandler( element, trackEvent, name, updateTrackEvent );
-              }
-              else {
-                _this.attachInputChangeHandler( element, trackEvent, name, updateTrackEvent );
-              }
+              _this.attachInputChangeHandler( element, trackEvent, name, updateTrackEvent );
             }
-          },
-          basicContainer: optionsContainer,
-          ignoreManifestKeys: [ "target", "start", "end" ],
-          safeCallback: updateTrackEvent
-        });
+          }
+        },
+        basicContainer: optionsContainer,
+        ignoreManifestKeys: [ "target", "start", "end" ],
+        safeCallback: updateTrackEvent
+      });
 
-        if ( trackEvent.manifest.options.target && !trackEvent.manifest.options.target.hidden ) {
-          targetList = _this.createTargetsList( _targets );
-          selectElement = targetList.querySelector( "select" );
-          // Attach the onchange handler to trackEvent is updated when <select> is changed
-          _this.attachSelectChangeHandler( selectElement, trackEvent, "target" );
-          optionsContainer.appendChild( targetList );
-        }
-
-        _this.updatePropertiesFromManifest( trackEvent, null, true );
-
-        // Catch the end of a transition for when the error message box opens/closes
-        if ( _this.scrollbar ) {
-          LangUtils.applyTransitionEndListener( _messageContainer.parentNode, _this.scrollbar.update );
-        }
-
-        _this.scrollbar.update();
-
-
-        // Update properties when TrackEvent is updated
-        trackEvent.listen( "trackeventupdated", onTrackEventUpdated );
-      },
-      close: function () {
-        _trackEvent.unlisten( "trackeventupdated", onTrackEventUpdated );
+      if ( trackEvent.manifest.options.target && !trackEvent.manifest.options.target.hidden ) {
+        targetList = _this.createTargetsList( _targets );
+        selectElement = targetList.querySelector( "select" );
+        // Attach the onchange handler to trackEvent is updated when <select> is changed
+        _this.attachSelectChangeHandler( selectElement, trackEvent, "target" );
+        optionsContainer.appendChild( targetList );
       }
-    });
+
+      _this.updatePropertiesFromManifest( trackEvent, null, true );
+
+      // Catch the end of a transition for when the error message box opens/closes
+      if ( _this.scrollbar ) {
+        LangUtils.applyTransitionEndListener( _messageContainer.parentNode, _this.scrollbar.update );
+      }
+
+      _this.scrollbar.update();
+
+      // Update properties when TrackEvent is updated
+      trackEvent.listen( "trackeventupdated", onTrackEventUpdated );
+
+      if ( _oldOpenEvent ) {
+        _oldOpenEvent.apply( this, arguments );
+      }
+    };
+    events.close = function () {
+      _trackEvent.unlisten( "trackeventupdated", onTrackEventUpdated );
+      if ( _oldCloseEvent ) {
+        _oldCloseEvent.apply( this, arguments );
+      }
+    };
+
+    Editor.TrackEventEditor.extend( _this, butter, rootElement, events );
 
     /**
      * Member: updateTrackEvent
@@ -125,5 +135,16 @@ define( [ "text!./default.html", "editor/editor", "util/lang" ],
         setErrorState( e.toString() );
       }
     }
-  });
+
+  }
+
+  Editor.register( "default", LAYOUT_SRC, DefaultEditor );
+
+  return {
+    extend: function( extendObject, rootElement, butter, compiledLayout, events ){
+      return DefaultEditor.apply( extendObject, [ rootElement, butter, compiledLayout, events ] );
+    },
+    EDITOR_SRC: LAYOUT_SRC
+  };
+
 });

--- a/src/editor/module.js
+++ b/src/editor/module.js
@@ -20,6 +20,9 @@ define( [ "core/eventmanager", "core/trackevent", "./editor",
 
   var DEFAULT_EDITOR_NAME = "plugin-list";
 
+  // Expose DefaultEditor to external editors
+  Editor.DefaultEditor = DefaultEditor;
+
   /**
    * Class: EventEditor
    *
@@ -203,7 +206,7 @@ define( [ "core/eventmanager", "core/trackevent", "./editor",
 
         if ( editorsToLoad.length > 0 ){
           butter.loader.load( editorsToLoad, function() {
-            Editor.loadUrlSpecifiedLayouts( onModuleReady, butter.config.value( "baseDir" ) );
+            Editor.initialize( onModuleReady, butter.config.value( "baseDir" ) );
           }, function( e ) {
             _logger.log( "Couldn't load editor " + e.target.src );
             

--- a/src/editor/trackevent-editor.js
+++ b/src/editor/trackevent-editor.js
@@ -65,37 +65,36 @@ define([ "util/lang", "util/keys", "util/time", "./base-editor", "ui/widget/tool
 
       if ( _oldOpenEvent ) {
         _oldOpenEvent.apply( this, arguments );
+      }
+      // Code for handling basic/advanced options tabs are going to be the same. If the user defined these buttons
+      // handle it for them here rather than force them to write the code in their editor
+      if ( basicButton && advancedButton ) {
+        basicButton.addEventListener( "mouseup", function( e ) {
+          if ( basicTab.classList.contains( "display-off" ) ) {
+            basicTab.classList.toggle( "display-off" );
+            advancedTab.classList.toggle( "display-off" );
+            basicButton.classList.add( "butter-active" );
+            advancedButton.classList.remove( "butter-active" );
+            extendObject.scrollbar.update();
+          }
+        });
 
-        // Code for handling basic/advanced options tabs are going to be the same. If the user defined these buttons
-        // handle it for them here rather than force them to write the code in their editor
-        if ( basicButton && advancedButton ) {
-          basicButton.addEventListener( "mouseup", function( e ) {
-            if ( basicTab.classList.contains( "display-off" ) ) {
-              basicTab.classList.toggle( "display-off" );
-              advancedTab.classList.toggle( "display-off" );
-              basicButton.classList.add( "butter-active" );
-              advancedButton.classList.remove( "butter-active" );
-              extendObject.scrollbar.update();
-            }
-          });
+        advancedButton.addEventListener( "mouseup", function( e ) {
+          if ( !basicTab.classList.contains( "display-off" ) ) {
+            basicTab.classList.toggle( "display-off" );
+            advancedTab.classList.toggle( "display-off" );
+            basicButton.classList.remove( "butter-active" );
+            advancedButton.classList.add( "butter-active" );
+            extendObject.scrollbar.update();
+          }
+        });
 
-          advancedButton.addEventListener( "mouseup", function( e ) {
-            if ( !basicTab.classList.contains( "display-off" ) ) {
-              basicTab.classList.toggle( "display-off" );
-              advancedTab.classList.toggle( "display-off" );
-              basicButton.classList.remove( "butter-active" );
-              advancedButton.classList.add( "butter-active" );
-              extendObject.scrollbar.update();
-            }
-          });
-
-          // Override default scrollbar to account for both tab containers
-          extendObject.addScrollbar({
-            inner: wrapper,
-            outer: wrapper,
-            appendTo: rootElement.querySelector( ".scrollbar-container" )
-          });
-        }
+        // Override default scrollbar to account for both tab containers
+        extendObject.addScrollbar({
+          inner: wrapper,
+          outer: wrapper,
+          appendTo: rootElement.querySelector( ".scrollbar-container" )
+        });
       }
 
       if ( extendObject.scrollbar ) {
@@ -722,7 +721,8 @@ define([ "util/lang", "util/keys", "util/time", "./base-editor", "ui/widget/tool
   }
 
   return {
-    extend: TrackEventEditor
+    extend: TrackEventEditor,
+    EDITOR_FRAGMENTS: __defaultLayouts
   };
 
 });

--- a/src/layouts/trackevent-editor-defaults.html
+++ b/src/layouts/trackevent-editor-defaults.html
@@ -2,6 +2,10 @@
       If a copy of the MIT license was not distributed with this file, you can
       obtain one at http://www.mozillapopcorn.org/butter-license.txt -->
 
+<div class="trackevent-warning">
+  <strong>Warning:</strong> <span class="trackevent-warning-message"></span>
+</div>
+
 <fieldset class="trackevent-property default input">
   <label class="property-name"></label>
   <input class="value" type="text" />

--- a/templates/assets/editors/webpage/webpage-editor.html
+++ b/templates/assets/editors/webpage/webpage-editor.html
@@ -1,0 +1,7 @@
+<!--  This Source Code Form is subject to the terms of the MIT license
+      If a copy of the MIT license was not distributed with this file, you can
+      obtain one at http://www.mozillapopcorn.org/butter-license.txt -->
+
+<div class="trackevent-warning">
+  <strong>Warning:</strong> Not all browsers can use the webpage plugin consistently with Popcorn Maker. If you would like to force Popcorn Maker to try, check the "Trust iframes" checkbox above. For more information, see <a target="_blank" href="https://developer.mozilla.org/en-US/docs/HTML/Element/iframe">this MDN article</a>.
+</div>

--- a/templates/assets/editors/webpage/webpage-editor.js
+++ b/templates/assets/editors/webpage/webpage-editor.js
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the MIT license
+ * If a copy of the MIT license was not distributed with this file, you can
+ * obtain one at http://www.mozillapopcorn.org/butter-license.txt */
+
+(function( Butter ) {
+
+  var Editor = Butter.Editor;
+
+  Editor.register( "webpage", [ Editor.DefaultEditor.EDITOR_SRC, "load!{{baseDir}}templates/assets/editors/webpage/webpage-editor.html" ],
+    function( rootElement, butter, compiledLayout ) {
+
+    var _rootElement = rootElement,
+        _this = this;
+
+    function setup( trackEvent ) {
+      var container = _rootElement.querySelector( ".editor-options" );
+
+      var warningDiv = compiledLayout.querySelector( ".trackevent-warning" );
+      container.appendChild( warningDiv );
+    }
+
+    Editor.DefaultEditor.extend( _this, rootElement, butter, compiledLayout, {
+      open: function( parentElement, trackEvent ) {
+        setup( trackEvent );
+      },
+      close: function() {
+      }
+    });
+
+  });
+
+}( window.Butter ));

--- a/templates/basic/config.json
+++ b/templates/basic/config.json
@@ -76,7 +76,8 @@
     "popup": "{{baseDir}}templates/assets/editors/popup/popup-editor.js",
     "image": "{{baseDir}}templates/assets/editors/image/image-editor.js",
     "text": "{{baseDir}}templates/assets/editors/text/text-editor.js",
-    "twitter": "{{baseDir}}templates/assets/editors/twitter/twitter-editor.js"
+    "twitter": "{{baseDir}}templates/assets/editors/twitter/twitter-editor.js",
+    "webpage": "{{baseDir}}templates/assets/editors/webpage/webpage-editor.js"
   },
   "maxPluginZIndex": 1000
 }


### PR DESCRIPTION
1. Method to extend Default editor, so new editors do not require large amounts of code to extend TrackEventEditor well.
2. Created webpage-editor.
3. General warning container in trackevent-editor-defaults.
4. Sandbox safety mechanism in popcorn.webpage.js.
5. Added webpage-editor to basic config.
6. Exposed useful layout sources and dom fragments through Editor, TrackEventEditor, DefaultEditor namespaces for easy extension.
