### PR TITLE
[t2024] Remove 'trackeventcreated' event.

### DIFF
--- a/src/editor/module.js
+++ b/src/editor/module.js
@@ -100,13 +100,6 @@ define( [ "core/eventmanager", "core/trackevent", "./editor",
       return _this.openEditor( editorType, false, trackEvent );
     };
 
-    // When a TrackEvent is somewhere in butter, open its editor immediately.
-    butter.listen( "trackeventcreated", function( e ) {
-      if ( [ "target", "media" ].indexOf( e.data.by ) > -1 ) {
-        _this.editTrackEvent( e.data.trackEvent );
-      }
-    });
-
     butter.listen( "trackeventadded", function ( e ) {
       var trackEvent = e.data,
           view = trackEvent.view,

--- a/src/timeline/media.js
+++ b/src/timeline/media.js
@@ -38,7 +38,6 @@ define( [ "core/trackevent", "core/track", "core/eventmanager",
         _trackHandles = new TrackHandles( butter, _media, _rootElement, _tracksContainer ),
         _trackEventHighlight = butter.config.value( "ui" ).trackEventHighlight || "click",
         _currentMouseDownTrackEvent,
-        _defaultTrackeventDuration = butter.config.value( "trackEvent" ).defaultDuration,
         _status;
 
     _status = new Status( _media, butter.ui.tray.statusArea );
@@ -225,45 +224,13 @@ define( [ "core/trackevent", "core/track", "core/eventmanager",
     butter.editor.listen( "editorminimized", onEditorMinimized );
 
     function onPluginDropped( e ) {
-
       var type = e.data.type,
           track = e.data.track,
           start = e.data.start,
-          end,
           trackEvent;
 
-      if ( start + _defaultTrackeventDuration > _media.duration ) {
-        start = _media.duration - _defaultTrackeventDuration;
-      }
-
-      end = start + _defaultTrackeventDuration;
-
-      var defaultTarget = butter.defaultTarget;
-      if ( !defaultTarget && butter.targets.length > 0 ) {
-        defaultTarget = butter.targets[ 0 ];
-      }
-
-      track = _media.forceEmptyTrackSpaceAtTime( track, start, end );
-
-      trackEvent = track.addTrackEvent({
-        popcornOptions: {
-          start: start,
-          end: end,
-          target: defaultTarget.elementID
-        },
-        type: type
-      });
-
-      trackEvent.update();
-
-      if ( defaultTarget ) {
-        defaultTarget.view.blink();
-      }
-
-      butter.dispatch( "trackeventcreated", {
-        trackEvent: trackEvent,
-        by: "media"
-      });
+      trackEvent = butter.generateSafeTrackEvent( type, start, track );
+      butter.editor.editTrackEvent( trackEvent );
     }
 
     this.destroy = function() {

--- a/test/core/core-trackevent/trackevent-creation.html
+++ b/test/core/core-trackevent/trackevent-creation.html
@@ -8,9 +8,9 @@
     <script src="../../butter.inject.js"></script>
     <script src="../../test-utils.js"></script>
     <script>
-      asyncTest( "Create TrackEvent object", 2, function(){
+      asyncTest( "Create TrackEvent object", 2, function() {
 
-        createButterCore( function( butter ){
+        createButterCore( function( butter ) {
 
           Popcorn.plugin( "createTrackEventTest", function() {} );
 
@@ -26,6 +26,49 @@
           start();
         });
       });
+
+      asyncTest( "Create TrackEvent using generateSafeTrackEvent", 5, function() {
+
+        createButterCore( function( butter ) {
+
+          var defaultTrackeventDuration = butter.defaultTrackeventDuration;
+
+          Popcorn.plugin( "generateTrackEventTest", function() {
+            return {
+              start: function() {
+
+              },
+              end: function() {
+
+              }
+            };
+          });
+
+          var m = butter.addMedia({ url: "../../../external/popcorn-js/test/italia.ogg", target: "mediaDiv" }),
+              t1 = m.addTrack(),
+              t2 = m.addTrack(),
+              target = butter.addTarget({
+                element: "targetDiv"
+              });
+
+          m.listen( "mediaready", function() {
+            var te1 = butter.generateSafeTrackEvent( "generateTrackEventTest", 0 ),
+                te2 = butter.generateSafeTrackEvent( "generateTrackEventTest", defaultTrackeventDuration * 0.5 ),
+                te3 = butter.generateSafeTrackEvent( "generateTrackEventTest", defaultTrackeventDuration * 0.75 ),
+                te4 = butter.generateSafeTrackEvent( "generateTrackEventTest", defaultTrackeventDuration * 2, t2 ),
+                te5 = butter.generateSafeTrackEvent( "generateTrackEventTest", defaultTrackeventDuration * 2 );
+
+            ok( te1.track === t1, "First trackevent was placed on first track" );
+            ok( te2.track === t2, "Second trackevent avoided collision with first trackevent, and was placed on second track." );
+            ok( te3.track !== t2 && te3.track !== t1, "Third trackevent avoided collision with second & first trackevents, and was placed on a new track." );
+            ok( te4.track === t2, "Trackevent placed in open space on second track." );
+            ok( te5.track === t1, "Trackevent placed in open space, with no explicit track." );
+
+            Popcorn.removePlugin( "generateTrackEventTest" );
+            start();
+          });
+        });
+      });
     </script>
   </head>
   <body>
@@ -36,6 +79,7 @@
     <ol id="qunit-tests"></ol>
     <div id="qunit-fixture">
       <div id="mediaDiv"></div>
+      <div id="targetDiv"></div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
1. Removed references to `trackeventcreated` event.
2. Editor.editTrackEvent called directly when trackevents are created.
3. butter.generateSafeTrackEvent.
4. Media diverts to using defaultTarget when plugin drop occurs.
5. Timeline's onplugindropped event uses generateSafeTrackEvent.
6. Some protection for defaultTarget.
7. Tests.
