### PR TITLE
[t2464] Better TrackEvent update error detection and recovery

### DIFF
--- a/editors/googlemap-editor.js
+++ b/editors/googlemap-editor.js
@@ -11,7 +11,6 @@
     var _this = this;
 
     var _rootElement = rootElement,
-        _messageContainer = _rootElement.querySelector( "div.error-message" ),
         _trackEvent,
         _popcornEventMapReference,
         _butter;
@@ -29,57 +28,6 @@
       }
       else {
         _popcornEventMapReference = _trackEvent.popcornTrackEvent._map;
-      }
-    }
-
-    /**
-     * Member: setErrorState
-     *
-     * Sets the error state of the editor, making an error message visible
-     *
-     * @param {String} message: Error message to display
-     */
-    function setErrorState( message ) {
-      if ( message ) {
-        _messageContainer.innerHTML = message;
-        _messageContainer.parentNode.style.height = _messageContainer.offsetHeight + "px";
-        _messageContainer.parentNode.style.visibility = "visible";
-        _messageContainer.parentNode.classList.add( "open" );
-      }
-      else {
-        _messageContainer.innerHTML = "";
-        _messageContainer.parentNode.style.height = "";
-        _messageContainer.parentNode.style.visibility = "";
-        _messageContainer.parentNode.classList.remove( "open" );
-      }
-    }
-
-    /**
-     * Member: updateTrackEventWithoutTryCatch
-     *
-     * Simple handler for updating a TrackEvent when needed
-     *
-     * @param {TrackEvent} trackEvent: TrackEvent to update
-     * @param {Object} updateOptions: TrackEvent properties to update
-     */
-    function updateTrackEventWithoutTryCatch( trackEvent, updateOptions ) {
-      trackEvent.update( updateOptions );
-    }
-
-    /**
-     * Member: updateTrackEventWithTryCatch
-     *
-     * Attempt to update the properties of a TrackEvent; set the error state if a failure occurs.
-     *
-     * @param {TrackEvent} trackEvent: TrackEvent to update
-     * @param {Object} properties: TrackEvent properties to update
-     */
-    function updateTrackEventWithTryCatch( trackEvent, properties ) {
-      try {
-        trackEvent.update( properties );
-      }
-      catch ( e ) {
-        setErrorState( e.toString() );
       }
     }
 
@@ -199,30 +147,31 @@
 
               attachTypeHandler( option );
             } else if ( option.elementType === "select" && key !== "type" ) {
-              _this.attachSelectChangeHandler( option.element, option.trackEvent, key, updateTrackEventWithoutTryCatch );
+              _this.attachSelectChangeHandler( option.element, option.trackEvent, key, _this.updateTrackEventSafe );
             } else if ( key === "fullscreen" ) {
               attachFullscreenHandler( option );
             } else if ( option.elementType === "input" ) {
-              _this.attachInputChangeHandler( option.element, option.trackEvent, key, updateTrackEventWithoutTryCatch );
+              _this.attachInputChangeHandler( option.element, option.trackEvent, key, _this.updateTrackEventSafe );
             }
           }
         }
       }
 
-      optionsContainer.appendChild( _this.createStartEndInputs( trackEvent, updateTrackEventWithTryCatch ) );
+      optionsContainer.appendChild( _this.createStartEndInputs( trackEvent, _this.updateTrackEventSafe ) );
 
       _this.createPropertiesFromManifest({
         trackEvent: trackEvent,
         callback: callback,
         basicContainer: optionsContainer,
-        ignoreManifestKeys: ignoreKeys,
-        safeCallback: updateTrackEventWithTryCatch
+        ignoreManifestKeys: ignoreKeys
       });
 
       attachHandlers();
 
       _this.updatePropertiesFromManifest( trackEvent );
       _this.scrollbar.update();
+
+      _this.setTrackEventUpdateErrorCallback( _this.setErrorState );
 
     }
 
@@ -235,7 +184,7 @@
         // Update properties when TrackEvent is updated
         trackEvent.listen( "trackeventupdated", function ( e ) {
           _this.updatePropertiesFromManifest( e.target );
-          setErrorState( false );
+          _this.setErrorState( false );
 
           // Now we REALLY know that we can try setting up listeners
           popcorn.on( "googlemaps-loaded", function() {

--- a/src/core/media.js
+++ b/src/core/media.js
@@ -71,11 +71,7 @@
               _this.duration = _popcornWrapper.duration;
               _ready = true;
               for( var i = 0, l = _tracks.length; i < l; i++ ) {
-                var te = _tracks[ i ].trackEvents;
-                for( var j = 0, k = te.length; j < k; j++ ) {
-                  // should call _popcornWrapper.updateEvent( te[ j ] ) circuitously
-                  te[ j ].update();
-                }
+                _tracks[ i ].updateTrackEvents();
               }
 
               // If the target element has a `data-butter-media-controls` property,

--- a/src/core/observer.js
+++ b/src/core/observer.js
@@ -1,0 +1,159 @@
+/* This Source Code Form is subject to the terms of the MIT license
+ * If a copy of the MIT license was not distributed with this file, you can
+ * obtain one at http://www.mozillapopcorn.org/butter-license.txt */
+
+define([], function(){
+
+  /**
+   * Notification
+   *
+   * A Notification object is passed to subscribers when a notification occurs. It
+   * describes the notification, encompassing references to the notification origin,
+   * the name of the notification, and some data to assist. Notifications can be
+   * cancelled by calling the `cancel` function, and a reason can be specified to
+   * pass on to the body which issued the notification.
+   *
+   * @param {Object} origin: The object which issued the notification.
+   * @param {String} type: The type of notification.
+   * @param {Object} data: Arbitrary data to associate with the notification.
+   */
+  function Notification( origin, type, data ) {
+    var _cancelledReason;
+
+    /**
+     * cancel
+     *
+     * Cancels a notification and records a reason for doing so.
+     *
+     * @param {String} reason: The reason for canceling the notification.
+     */
+    this.cancel = function( reason ) {
+      _cancelledReason = reason || true;
+    };
+
+    Object.defineProperties( this, {
+      origin: {
+        value: origin,
+        enumerable: true
+      },
+      type: {
+        value: type,
+        enumerable: true
+      },
+      data: {
+        value: data,
+        enumerable: true
+      },
+      cancelledReason: {
+        enumerable: true,
+        get: function() {
+          return _cancelledReason;
+        }
+      },
+      cancelled: {
+        enumerable: true,
+        get: function() {
+          return !!_cancelledReason;
+        }
+      }
+    });
+  }
+
+  /**
+   * __subscribe
+   *
+   * A class function which adds a subscriber to a group of subscribers
+   * corresponding to a given notification type.
+   *
+   * @param {String} type: The type of notification that the given subscriber should receive.
+   * @param {Function} subscriber: A function which will be called when notification occurs.
+   * @param {Object} subscriberDict: The group of subscribers for an object.
+   */
+  function __subscribe( type, subscriber, subscriberDict ) {
+    if ( !subscriberDict[ type ] ) {
+      subscriberDict[ type ] = [];
+    }
+    subscriberDict[ type ].push( subscriber );
+  }
+
+  /**
+   * __unsubscribe
+   *
+   * A class function which removes a subscriber from a group of subscribers
+   * corresponding to a given notification type.
+   *
+   * @param {String} type: The type of notification that the given subscriber was set up to receive.
+   * @param {Function} subscriber: A function which will be called when notification occurs.
+   * @param {Object} subscriberDict: The group of subscribers for an object.
+   */
+  function __unsubscribe( type, subscriber, subscriberDict ) {
+    var idx, subscribers = subscriberDict[ type ];
+
+    if ( subscribers ) {
+      idx = subscribers.indexOf( subscriber );
+      if ( idx > -1 ) {
+        subscribers.splice( idx, 1 );
+      }
+    }
+  }
+
+  /**
+   * __notify
+   *
+   * A class function which calls all the subscribers of a given notification type.
+   *
+   * @param {String} type: The type of notification identifying a group of subscribers.
+   * @param {Function} subscriber: A function which will be called when notification occurs.
+   * @param {Object} subscriberDict: The group of subscribers for an object.
+   * @param {Object} object: The object issuing the notification.
+   */
+  function __notify( type, data, subscriberDict, object ) {
+    var i, l,
+        subscribers = subscriberDict[ type ],
+        notification = new Notification( object, type, data );
+
+    if ( subscribers ) {
+      for ( i = 0, l = subscribers.length; i < l; ++i ) {
+        subscribers[ i ]( notification );
+        if ( notification.cancelled ) {
+          break;
+        }
+      }
+    }
+
+    return notification;
+  }
+
+  /**
+   * extendObject
+   *
+   * Gives an object the functionality to record and notify subscribers for typed notifications
+   * (simple implementation of Observer pattern).
+   *
+   * @param {Object} object: The object to extend with Observer functionality.
+   */
+  function extendObject( object ) {
+    var _subscribers = {};
+
+    if ( object.subscribe ) {
+      throw "Object already has Observer properties.";
+    }
+
+    object.subscribe = function( type, subscriber ) {
+      __subscribe( type, subscriber, _subscribers );
+    };
+
+    object.unsubscribe = function( type, subscriber ) {
+      __unsubscribe( type, subscriber, _subscribers );
+    };
+
+    object.notify = function( type, data ) {
+      return __notify( type, data, _subscribers, object );
+    };
+  }
+
+  return {
+    extend: extendObject
+  };
+
+});

--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -324,12 +324,14 @@ define( [ "core/eventmanager", "./toggler",
         };
 
     butter.listen( "trackeventadded", function( e ) {
-      orderedTrackEvents.push( e.data );
+      var trackEvent = e.data;
+      orderedTrackEvents.push( trackEvent );
       orderedTrackEvents.sort( sortTrackEvents );
     }); // listen
 
     butter.listen( "trackeventremoved", function( e ) {
-      var index = orderedTrackEvents.indexOf( e.data );
+      var trackEvent = e.data,
+          index = orderedTrackEvents.indexOf( trackEvent );
       if( index > -1 ){
         orderedTrackEvents.splice( index, 1 );
       } // if

--- a/templates/assets/editors/image/image-editor.js
+++ b/templates/assets/editors/image/image-editor.js
@@ -10,7 +10,6 @@
                    function( rootElement, butter, compiledLayout ) {
 
     var _rootElement = rootElement,
-        _messageContainer = _rootElement.querySelector( "div.error-message" ),
         _tagRadio = _rootElement.querySelector( "#image-tag-radio" ),
         _galleryRadio = _rootElement.querySelector( "#image-gallery-radio" ),
         _tagInput = _rootElement.querySelector( "#image-tag-input" ),
@@ -32,27 +31,9 @@
         _popcornInstance,
         _cachedValues;
 
-    function setErrorState( message ) {
-      if ( message ) {
-        _messageContainer.innerHTML = message;
-        _messageContainer.parentNode.style.height = _messageContainer.offsetHeight + "px";
-        _messageContainer.parentNode.style.visibility = "visible";
-        _messageContainer.parentNode.classList.add( "open" );
-      } else {
-        _messageContainer.innerHTML = "";
-        _messageContainer.parentNode.style.height = "0px";
-        _messageContainer.parentNode.style.visibility = "hidden";
-        _messageContainer.parentNode.classList.remove( "open" );
-      }
-    }
-
     function updateTrackEvent( te, props ) {
-      setErrorState();
-      try {
-        te.update( props );
-      } catch ( e ) {
-        setErrorState( e.toString() );
-      }
+      _this.setErrorState();
+      _this.updateTrackEventSafe( te, props );
     }
 
     function toggleTabs() {
@@ -81,7 +62,7 @@
       } else if ( window.webkitURL ) {
         imgSrc = window.webkitURL.createObjectURL( file );
       } else {
-        setErrorState( "Sorry, but your browser doesn't support this feature." );
+        _this.setErrorState( "Sorry, but your browser doesn't support this feature." );
       }
 
       image = document.createElement( "img" );
@@ -313,7 +294,7 @@
           var count = prop.count > 0 ? prop.count : 1;
 
           if ( count > _maxImageCount ) {
-            setErrorState( "Error: Image count must be less than " + _maxImageCount + "." );
+            _this.setErrorState( "Error: Image count must be less than " + _maxImageCount + "." );
             return;
           }
 
@@ -346,13 +327,13 @@
         trackEvent: trackEvent,
         callback: callback,
         basicContainer: container,
-        manifestKeys: [ "transition" ],
-        safeCallback: updateTrackEvent
+        manifestKeys: [ "transition" ]
       });
 
       attachHandlers();
 
       _this.updatePropertiesFromManifest( trackEvent );
+      _this.setTrackEventUpdateErrorCallback( _this.setErrorState );
 
       if ( trackEvent.popcornOptions.src ) {
         _singleActive = true;
@@ -416,7 +397,7 @@
 
         // The current popcorn instance
         _popcornInstance.on( "invalid-flickr-image", function() {
-          setErrorState( "Invalid Flicker Gallery URL. E.G: http://www.flickr.com/photos/etherworks/sets/72157630563520740/" );
+          _this.setErrorState( "Invalid Flicker Gallery URL. E.G: http://www.flickr.com/photos/etherworks/sets/72157630563520740/" );
         });
 
         _trackEvent.listen( "trackeventupdated", function( e ) {

--- a/templates/assets/editors/popup/popup-editor.js
+++ b/templates/assets/editors/popup/popup-editor.js
@@ -10,60 +10,8 @@
     var _this = this;
 
     var _rootElement = rootElement,
-        _messageContainer = _rootElement.querySelector( "div.error-message" ),
         _trackEvent,
         _butter;
-
-    /**
-     * Member: setErrorState
-     *
-     * Sets the error state of the editor, making an error message visible
-     *
-     * @param {String} message: Error message to display
-     */
-    function setErrorState( message ) {
-      if ( message ) {
-        _messageContainer.innerHTML = message;
-        _messageContainer.parentNode.style.height = _messageContainer.offsetHeight + "px";
-        _messageContainer.parentNode.style.visibility = "visible";
-        _messageContainer.parentNode.classList.add( "open" );
-      }
-      else {
-        _messageContainer.innerHTML = "";
-        _messageContainer.parentNode.style.height = "";
-        _messageContainer.parentNode.style.visibility = "";
-        _messageContainer.parentNode.classList.remove( "open" );
-      }
-    }
-
-    /**
-     * Member: updateTrackEventWithoutTryCatch
-     *
-     * Simple handler for updating a TrackEvent when needed
-     *
-     * @param {TrackEvent} trackEvent: TrackEvent to update
-     * @param {Object} updateOptions: TrackEvent properties to update
-     */
-    function updateTrackEventWithoutTryCatch( trackEvent, updateOptions ) {
-      trackEvent.update( updateOptions );
-    }
-
-    /**
-     * Member: updateTrackEventWithTryCatch
-     *
-     * Attempt to update the properties of a TrackEvent; set the error state if a failure occurs.
-     *
-     * @param {TrackEvent} trackEvent: TrackEvent to update
-     * @param {Object} properties: TrackEvent properties to update
-     */
-    function updateTrackEventWithTryCatch( trackEvent, properties ) {
-      try {
-        trackEvent.update( properties );
-      }
-      catch ( e ) {
-        setErrorState( e.toString() );
-      }
-    }
 
     /**
      * Member: setup
@@ -130,7 +78,7 @@
 
         function colorCallback( te, prop, message ) {
           if ( message ) {
-            setErrorState( message );
+            _this.setErrorState( message );
             return;
           } else {
             te.update({
@@ -160,7 +108,7 @@
               attachTypeHandler( option );
             }
             else if ( option.elementType === "select" && key !== "type" ) {
-              _this.attachSelectChangeHandler( option.element, option.trackEvent, key, updateTrackEventWithoutTryCatch );
+              _this.attachSelectChangeHandler( option.element, option.trackEvent, key, _this.updateTrackEventSafe );
             }
             else if ( option.elementType === "input" ) {
               if ( key === "linkUrl" ) {
@@ -176,19 +124,19 @@
               }
 
               if ( option.element.type === "checkbox" ) {
-                _this.attachCheckboxChangeHandler( option.element, option.trackEvent, key, updateTrackEventWithoutTryCatch );
+                _this.attachCheckboxChangeHandler( option.element, option.trackEvent, key, _this.updateTrackEventSafe );
               }
               else if ( key === "fontColor" ) {
                 _this.attachColorChangeHandler( option.element, option.trackEvent, key, colorCallback );
               }
               else {
-                _this.attachInputChangeHandler( option.element, option.trackEvent, key, updateTrackEventWithoutTryCatch );
+                _this.attachInputChangeHandler( option.element, option.trackEvent, key, _this.updateTrackEventSafe );
               }
             }
           }
         }
 
-        basicContainer.insertBefore( _this.createStartEndInputs( trackEvent, updateTrackEventWithTryCatch ), basicContainer.firstChild );
+        basicContainer.insertBefore( _this.createStartEndInputs( trackEvent, _this.updateTrackEventSafe ), basicContainer.firstChild );
       }
 
       _this.createPropertiesFromManifest({
@@ -196,12 +144,12 @@
         callback: callback,
         basicContainer: basicContainer,
         advancedContainer: advancedContainer,
-        safeCallback: updateTrackEventWithTryCatch,
         ignoreManifestKeys: [ "start", "end" ]
       });
 
       attachHandlers();
       _this.updatePropertiesFromManifest( trackEvent );
+      _this.setTrackEventUpdateErrorCallback( _this.setErrorState );
     }
 
     function clicking( e ) {
@@ -232,7 +180,7 @@
           anchorClickPrevention( anchorContainer );
 
           _this.updatePropertiesFromManifest( _trackEvent );
-          setErrorState( false );
+          _this.setErrorState( false );
         });
         setup( trackEvent );
       },

--- a/templates/assets/editors/text/text-editor.js
+++ b/templates/assets/editors/text/text-editor.js
@@ -10,60 +10,8 @@
     var _this = this;
 
     var _rootElement = rootElement,
-        _messageContainer = _rootElement.querySelector( "div.error-message" ),
         _trackEvent,
         _butter;
-
-    /**
-     * Member: setErrorState
-     *
-     * Sets the error state of the editor, making an error message visible
-     *
-     * @param {String} message: Error message to display
-     */
-    function setErrorState( message ) {
-      if ( message ) {
-        _messageContainer.innerHTML = message;
-        _messageContainer.parentNode.style.height = _messageContainer.offsetHeight + "px";
-        _messageContainer.parentNode.style.visibility = "visible";
-        _messageContainer.parentNode.classList.add( "open" );
-      }
-      else {
-        _messageContainer.innerHTML = "";
-        _messageContainer.parentNode.style.height = "";
-        _messageContainer.parentNode.style.visibility = "";
-        _messageContainer.parentNode.classList.remove( "open" );
-      }
-    }
-
-    /**
-     * Member: updateTrackEventWithoutTryCatch
-     *
-     * Simple handler for updating a TrackEvent when needed
-     *
-     * @param {TrackEvent} trackEvent: TrackEvent to update
-     * @param {Object} updateOptions: TrackEvent properties to update
-     */
-    function updateTrackEventWithoutTryCatch( trackEvent, updateOptions ) {
-      trackEvent.update( updateOptions );
-    }
-
-    /**
-     * Member: updateTrackEventWithTryCatch
-     *
-     * Attempt to update the properties of a TrackEvent; set the error state if a failure occurs.
-     *
-     * @param {TrackEvent} trackEvent: TrackEvent to update
-     * @param {Object} properties: TrackEvent properties to update
-     */
-    function updateTrackEventWithTryCatch( trackEvent, properties ) {
-      try {
-        trackEvent.update( properties );
-      }
-      catch ( e ) {
-        setErrorState( e.toString() );
-      }
-    }
 
     /**
      * Member: setup
@@ -89,7 +37,7 @@
 
         function colorCallback( te, prop, message ) {
           if ( message ) {
-            setErrorState( message );
+            _this.setErrorState( message );
             return;
           } else {
             te.update({
@@ -103,7 +51,7 @@
             option = pluginOptions[ key ];
 
             if ( option.elementType === "select" ) {
-              _this.attachSelectChangeHandler( option.element, option.trackEvent, key, updateTrackEventWithoutTryCatch );
+              _this.attachSelectChangeHandler( option.element, option.trackEvent, key, _this.updateTrackEventSafe );
             }
             else if ( option.elementType === "input" ) {
               if ( key === "linkUrl" ) {
@@ -119,18 +67,18 @@
               }
 
               if ( option.element.type === "checkbox" ) {
-                _this.attachCheckboxChangeHandler( option.element, option.trackEvent, key, updateTrackEventWithoutTryCatch );
+                _this.attachCheckboxChangeHandler( option.element, option.trackEvent, key, _this.updateTrackEventSafe );
               } else if ( key === "fontColor" ) {
                 _this.attachColorChangeHandler( option.element, option.trackEvent, key, colorCallback );
               }
               else {
-                _this.attachInputChangeHandler( option.element, option.trackEvent, key, updateTrackEventWithoutTryCatch );
+                _this.attachInputChangeHandler( option.element, option.trackEvent, key, _this.updateTrackEventSafe );
               }
             }
           }
         }
 
-        basicContainer.insertBefore( _this.createStartEndInputs( trackEvent, updateTrackEventWithTryCatch ), basicContainer.firstChild );
+        basicContainer.insertBefore( _this.createStartEndInputs( trackEvent, _this.updateTrackEventSafe ), basicContainer.firstChild );
       }
 
       _this.createPropertiesFromManifest({
@@ -138,12 +86,12 @@
         callback: callback,
         basicContainer: basicContainer,
         advancedContainer: advancedContainer,
-        safeCallback: updateTrackEventWithTryCatch,
         ignoreManifestKeys: [ "start", "end" ]
       });
 
       attachHandlers();
       _this.updatePropertiesFromManifest( trackEvent );
+      _this.setTrackEventUpdateErrorCallback( _this.setErrorState );
     }
 
     function clicking( e ) {
@@ -174,7 +122,7 @@
           anchorClickPrevention( anchorContainer );
 
           _this.updatePropertiesFromManifest( _trackEvent );
-          setErrorState( false );
+          _this.setErrorState( false );
         });
         setup( trackEvent );
       },

--- a/templates/basic/saved-data.json
+++ b/templates/basic/saved-data.json
@@ -27,7 +27,19 @@
               "type": "text",
               "popcornOptions": {
                 "start": 1,
-                "end": 6,
+                "end": 2.8,
+                "target": "video-container",
+                "text": "Pop some corn!"
+              },
+              "track": "Track0",
+              "name": "TrackEvent3"
+            },
+            {
+              "id": "TrackEvent3",
+              "type": "text",
+              "popcornOptions": {
+                "start": 3,
+                "end": 5,
                 "target": "video-container",
                 "text": "Pop some corn!"
               },

--- a/test/index.html
+++ b/test/index.html
@@ -30,6 +30,7 @@
       <a target="_blank" href="core/core-trackevent/index.html">Core Track Event</a> |
       <a target="_blank" href="editor/index.html">Editor</a> |
       <a target="_blank" href="eventmanager/index.html">Eventmanager Module</a> |
+      <a target="_blank" href="observer/index.html">Observer Module</a> |
       <a target="_blank" href="logger/index.html">Logger Module</a> |
       <a target="_blank" href="media/index.html">Media Module</a> |
       <a target="_blank" href="page/index.html">Page Module</a> |

--- a/test/observer/index.html
+++ b/test/observer/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Butter Test Suite [Observer]</title>
+	  <link rel="stylesheet" href="../qunit/qunit.css" type="text/css" media="screen">
+	  <script type="text/javascript" src="../qunit/qunit.js"></script>
+    <script type="text/javascript" src="../inject.js"></script>
+    <script type="text/javascript" src="../../src/butter.js"></script>
+    <script src="../butter.inject.js"></script>\
+    <script>
+      require( [ "../src/core/observer" ], function( Observer ) {
+        Observer.extend( window );
+
+        test( "Observer existence" , function () {
+          ok( Observer, "Observer exists" );
+        });
+
+
+        test( "Observer wrapping" , function () {
+          var o = {};
+          Observer.extend( o );
+
+          ok( o.subscribe && typeof o.subscribe === "function", "Observer.extend adds subscribe" );
+          ok( o.unsubscribe && typeof o.unsubscribe === "function", "Observer.extend adds unsubscribe" );
+          ok( o.notify && typeof o.notify === "function", "Observer.extend adds notify" );
+        });
+
+
+        asyncTest( "Simple notification subscription & unsubscription", 9, function() {
+          var a = {},
+              name = "eventA",
+              data = "eventA data",
+              notification,
+              notificationsReceived = 0;
+
+          Observer.extend( a );
+
+          function eventAHandler( e ) {
+            ++notificationsReceived;
+            ok( true, "eventA handler fired" );
+            ok( e, "got event object" );
+            ok( e.type &&
+                e.origin &&
+                e.data &&
+                e.cancel && typeof e.cancel === "function",
+                "event has proper structure" );
+            ok( e.data === data, "data passed on event object" );
+            ok( e.origin === a, "correct target on event object" );
+            ok( e.type === name, "correct name on event type" );
+          }
+
+          a.subscribe( name, eventAHandler );
+
+          notification = a.notify( name, data );
+          ok( !!notification, "Notification was issued." );
+
+          a.unsubscribe( name, eventAHandler );
+
+          notification = a.notify( name, data );
+          ok( !!notification, "Notification was issued again." );
+
+          ok( notificationsReceived === 1, "unsubscribe was successful" );
+
+          start();
+        });
+
+        asyncTest( "Cancelling notifications", 3, function() {
+          var a = {},
+              name = "eventA",
+              data = "eventA data",
+              notification,
+              notificationsReceived = "";
+
+          Observer.extend( a );
+
+          function eventAHandler( e ) {
+            notificationsReceived += "A";
+            e.cancel( "A" );
+          }
+
+          function eventBHandler( e ) {
+            notificationsReceived += "B";
+            e.cancel( "B" );
+          }
+
+          a.subscribe( name, eventAHandler );
+          a.subscribe( name, eventBHandler );
+
+          notification = a.notify( name, data );
+          ok( notification.cancelled, "Notification was cancelled." );
+          ok( notificationsReceived === "A", "Notification only reached handler A" );
+          ok( notification.cancelledReason === "A", "Reason for cancellation was recorded" );
+
+          start();
+        });
+      });
+    </script>
+  </head>
+  <body>
+    <h1 id="qunit-header">Butter API Test Suite [EventManagerWrapper]</h1>
+    <h2 id="qunit-banner"></h2>
+    <div id="qunit-testrunner-toolbar"></div>
+    <h2 id="qunit-userAgent"></h2>
+    <ol id="qunit-tests"></ol>
+  </body>
+</html>

--- a/test/track/track-removeEmptyTrack.html
+++ b/test/track/track-removeEmptyTrack.html
@@ -24,14 +24,15 @@
               t2 = butter.tracks[ 1 ];
 
           butter.listen( "trackremoved", function( e ) {
-            equal( butter.tracks.length, 1, "Track was removed when it no longer had any trackEvents left" );
             equal( butter.tracks[ 0 ].id, t2.id, "Track 1 was removed, only track 2 exists now" );
             start();
           });
+
           t.addTrackEvent( defaultEvent );
-          t2.addTrackEvent( defaultEvent );
           t.removeTrackEvent( t.trackEvents[ 0 ] );
           butter.currentMedia.cleanUpEmptyTracks();
+
+          equal( butter.tracks.length, 1, "Track was removed when it no longer had any trackEvents left" );
         });
       });
     </script>

--- a/tests.conf
+++ b/tests.conf
@@ -36,6 +36,7 @@
     "editor-custom": "test/editor/editor-custom.html",
     "editor-createStartEndInputs": "test/editor/editor-createStartEndInputs.html",
     "eventmanager": "test/eventmanager/index.html",
+    "observer": "test/observer/index.html",
     "config": "test/config/index.html",
     "logger": "test/logger/index.html",
     "popcorn-wrapper": "test/popcorn-wrapper/index.html",


### PR DESCRIPTION
1. Created src/core/observer to give classes ability to notify subscribers of events (synchronous).
2. Created src/strings to start holding Butter-wide strings.
3. Removed independent setErrorState, updateTrackEvent\* from editors.
4. Added centralized updateTrackEventSafe to TrackEventEditor.
5. Rerouted TrackEvent update mechanisms to use updateTrackEventSafe in editors.
6. Added trackevent update subscriber to src/core/track to reject an update if overlap occurs.
