### PR TITLE
[#2211] Don't cancel loading of media on a timeout

### DIFF
--- a/src/core/media.js
+++ b/src/core/media.js
@@ -87,7 +87,6 @@
             },
             timeout: function(){
               _this.dispatch( "mediatimeout" );
-              _this.dispatch( "mediafailed", "timeout" );
             },
             fail: function( e ){
               _this.dispatch( "mediafailed", "error" );

--- a/src/core/popcorn-wrapper.js
+++ b/src/core/popcorn-wrapper.js
@@ -127,14 +127,19 @@ define( [ "core/logger", "core/eventmanager", "util/uri" ], function( Logger, Ev
     this.prepare = function( url, target, popcornOptions, callbacks, scripts ){
       var urlsFromString;
 
-      // called when timeout occurs preparing popcorn or the media
-      function timeoutWrapper( e ){
+      // called when timeout occurs preparing popcorn
+      function popcornTimeoutWrapper( e ) {
         _interruptLoad = true;
         _onTimeout( e );
       }
 
+      // called when timeout occurs preparing media
+      function mediaTimeoutWrapper( e ) {
+        _onTimeout( e );
+      }
+
       // called when there's a serious failure in preparing popcorn
-      function failureWrapper( e ){
+      function failureWrapper( e ) {
         _interruptLoad = true;
         _logger.log( e );
         _onFail( e );
@@ -177,8 +182,8 @@ define( [ "core/logger", "core/eventmanager", "util/uri" ], function( Logger, Ev
             // once popcorn is created, attach listeners to it to detect state
             addPopcornHandlers();
             // wait for the media to become available and notify the user, or timeout
-            waitForMedia( _onPrepare, timeoutWrapper );
-          }, timeoutWrapper );
+            waitForMedia( _onPrepare, mediaTimeoutWrapper );
+          }, popcornTimeoutWrapper );
         }
         catch( e ) {
           // if we've reached here, we have an internal failure in butter or popcorn
@@ -320,7 +325,7 @@ define( [ "core/logger", "core/eventmanager", "util/uri" ], function( Logger, Ev
         if ( trackEvents ) {
           for ( i = trackEvents.length - 1; i >= 0; i-- ) {
             popcornOptions = trackEvents[ i ].popcornOptions;
-          
+
             saveOptions = {};
             for ( option in popcornOptions ) {
               if ( popcornOptions.hasOwnProperty( option ) ) {

--- a/src/editor/media-editor.js
+++ b/src/editor/media-editor.js
@@ -5,8 +5,9 @@
 define( [ "util/lang", "util/uri", "util/keys", "editor/editor", "text!layouts/media-editor.html" ],
   function( LangUtils, URI, KeysUtils, Editor, EDITOR_LAYOUT ) {
 
-  var MAX_MEDIA_INPUTS = 4,
-      _parentElement =  LangUtils.domFragment( EDITOR_LAYOUT,".media-editor" ),
+  var MAX_MEDIA_INPUTS = 4;
+
+  var _parentElement =  LangUtils.domFragment( EDITOR_LAYOUT,".media-editor" ),
       _loadingSpinner = _parentElement.querySelector( ".media-loading-spinner" ),
       _primaryMediaWrapper = LangUtils.domFragment( EDITOR_LAYOUT, ".primary-media-wrapper" ),
       _altMediaWrapper = LangUtils.domFragment( EDITOR_LAYOUT, ".alt-media-wrapper" ),
@@ -189,9 +190,8 @@ define( [ "util/lang", "util/uri", "util/keys", "editor/editor", "text!layouts/m
 
   _addAlternateSourceBtn.addEventListener( "click", addAlternateSourceBtnHandler, false );
 
-  function onMediaFailed() {
+  function onMediaTimeout() {
     showError( true );
-    setLoadSpinner( false );
   }
 
   function onMediaReady() {
@@ -214,7 +214,7 @@ define( [ "util/lang", "util/uri", "util/keys", "editor/editor", "text!layouts/m
 
         _media.listen( "mediaready", onMediaReady );
         _media.listen( "mediacontentchanged", onMediaContentChanged );
-        _media.listen( "mediafailed", onMediaFailed );
+        _media.listen( "mediatimeout", onMediaTimeout );
 
         // Ensure the loading spinner is off when the media is ready. Otherwise, keep it spinning.
         if ( _media.ready ) {
@@ -229,7 +229,7 @@ define( [ "util/lang", "util/uri", "util/keys", "editor/editor", "text!layouts/m
       close: function() {
         _media.unlisten( "mediaready", onMediaReady );
         _media.unlisten( "mediacontentchanged", onMediaContentChanged );
-        _media.unlisten( "mediafailed", onMediaFailed );
+        _media.unlisten( "mediatimeout", onMediaTimeout );
         document.querySelector( ".butter-editor-header-media" ).classList.remove( "butter-active" );
       }
     });

--- a/src/layouts/media-editor.html
+++ b/src/layouts/media-editor.html
@@ -1,15 +1,15 @@
 <div class="media-editor butter-editor fadable alternates-hidden allow-scrollbar">
   <h1>Change Media Source
-    <span class="media-loading-spinner hidden" ></span>
+    <span class="media-loading-spinner"></span>
   </h1>
   <div class="butter-editor-body scrollbar-container">
     <div class="scrollbar-outer">
       <div class="scrollbar-inner">
         <fieldset>
+          <label class="media-error-message hidden">Your media seems to be taking a long time to load. Review your media URL(s) or continue waiting.</label>
           <span class="current-media-wrapper"></span>
           <p class="add-alternate-media-source-desc">You need .webm, .mp4, and .ogv versions of your HTML5 video to support all major browsers.</p>
           <a class="add-alternate-media-source-btn butter-btn btn-light">Add Alternate</a>
-          <label class="media-error-message hidden">Error: one or more media sources failed to load!</label>
         </fieldset>
       </div>
     </div>


### PR DESCRIPTION
Lighthouse: https://webmademovies.lighthouseapp.com/projects/65733-popcorn-maker/tickets/2211-popcorn-wrapper-should-warn-but-not-stop-waiting-for-media-on-timeout#ticket-2211-8
