### PR TITLE
[#2552] Force plugin root for icons pathing to be relative. Base tag will take care of the rest

### DIFF
--- a/templates/assets/plugins/popup/popcorn.popup.js
+++ b/templates/assets/plugins/popup/popcorn.popup.js
@@ -6,7 +6,7 @@
       events = [],
       soundIndex = 0,
       MAX_AUDIO_TIME = 2,
-      _pluginRoot = location.protocol + "//" + location.hostname + ( location.port ? ":" + location.port : "" ) + "/templates/assets/plugins/popup/",
+      _pluginRoot = "/templates/assets/plugins/popup/",
       FILL_STYLE = "rgb(255, 255, 255)",
       innerDivTriangles = {},
       DEFAULT_FONT = "Tangerine";


### PR DESCRIPTION
https://webmademovies.lighthouseapp.com/projects/65733-popcorn-maker/tickets/2552-pop-up-icons-not-appearing
