### PR TITLE
[#2637] Fix regression of double clicking to add a new track event not opening the editor 

### DIFF
--- a/src/plugin/plugin-list.js
+++ b/src/plugin/plugin-list.js
@@ -57,8 +57,11 @@ define( [ "util/dragndrop", "util/lang", "editor/editor", "text!layouts/plugin-l
       });
 
       function onDoubleClick() {
+        var trackEvent;
+
         if ( butter.currentMedia.ready ) {
-          butter.generateSafeTrackEvent( e.data.type, butter.currentTime );
+          trackEvent = butter.generateSafeTrackEvent( e.data.type, butter.currentTime );
+          butter.editor.editTrackEvent( trackEvent );
         }
       }
 


### PR DESCRIPTION
https://webmademovies.lighthouseapp.com/projects/65733/tickets/2637-double-clicking-to-add-a-new-track-event-no-longer-opens-the-editor-immediately
