### PR TITLE
[#2638] Prevent images inside droppable containers being draggable. Ensure drag over class is removed properly

### DIFF
--- a/templates/assets/editors/editorhelper.js
+++ b/templates/assets/editors/editorhelper.js
@@ -245,13 +245,18 @@
         dropContainer.classList.remove( "butter-dragover" );
       }, false );
 
+      dropContainer.addEventListener( "mousedown", function( e ) {
+        // Prevent being able to drag the images inside and re drop them
+        e.preventDefault();
+      }, false );
+
       dropContainer.addEventListener( "drop", function( e ) {
         var file, imgSrc, imgURI, image, div;
 
         e.preventDefault();
         e.stopPropagation();
 
-        dropContainer.classList.add( "butter-dropped" );
+        dropContainer.classList.remove( "butter-dragover" );
 
         if ( !e.dataTransfer || !e.dataTransfer.files || !e.dataTransfer.files[ 0 ] ) {
           butter.dispatch( "droppable-unsupported" );


### PR DESCRIPTION
https://webmademovies.lighthouseapp.com/projects/65733/tickets/2638-dragging-images-on-the-video-and-dropping-in-droppable-area-causes-unexpected-error-messages
