### PR TITLE
[#2526] Update tests to use NullVideoWrapper to put less of a strain on resources.

### DIFF
--- a/test/core/saved-data-0000.json
+++ b/test/core/saved-data-0000.json
@@ -10,12 +10,9 @@
     {
       "id": "Media0",
       "name": "Media0",
-      "url": [
-        "../../external/popcorn-js/test/trailer.ogv",
-        "../../external/popcorn-js/test/trailer.mp4"
-      ],
+      "url": "#t=,200",
       "target": "mediaDiv",
-      "duration": 64.54166412353516,
+      "duration": 200,
       "tracks": [
         {
           "name": "Track0",

--- a/test/saved-data-0000.json
+++ b/test/saved-data-0000.json
@@ -10,12 +10,9 @@
     {
       "id": "Media0",
       "name": "Media0",
-      "url": [
-        "../../external/popcorn-js/test/trailer.ogv",
-        "../../external/popcorn-js/test/trailer.mp4"
-      ],
+      "url": "#t=,200",
       "target": "mediaDiv",
-      "duration": 64.54166412353516,
+      "duration": 200,
       "tracks": [
         {
           "name": "Track0",

--- a/test/trackevent/trackevent-preview-text.html
+++ b/test/trackevent/trackevent-preview-text.html
@@ -20,7 +20,8 @@
                 }
               },
               t = butter.currentMedia.tracks[ 0 ],
-              previewStrings = [ "This is a test", defaultEvent.popcornOptions.text ];
+              previewStrings = [ "This is a test", defaultEvent.popcornOptions.text ],
+              te;
 
           butter.listen( "trackeventupdated", function onTrackEventUpdated( e ) {
             var te = e.target;
@@ -36,7 +37,8 @@
               });
             }
           });
-          t.addTrackEvent( defaultEvent );
+          te = t.addTrackEvent( defaultEvent );
+          te.update();
         });
       });
     </script>

--- a/test/trackevent/trackevent-updateInvalid.html
+++ b/test/trackevent/trackevent-updateInvalid.html
@@ -11,29 +11,27 @@
     <script>
       asyncTest( "update w/ invalid options", 3, function() {
         createButterModule( function( butter ) {
-          butter.currentMedia.onReady( function() {
-            var te = butter.currentMedia.tracks[ 1 ].trackEvents[ 0 ];
+          var te = butter.currentMedia.tracks[ 1 ].trackEvents[ 0 ];
+
+          try {
+            te.update( { start: "m", end: 3 } );
+          } catch( e ) {
+            equal( e.reason, "invalid-start-time", "Correctly caught " + e.reason );
 
             try {
-              te.update( { start: "m", end: 3 } );
-            } catch( e ) {
-              equal( e.reason, "invalid-start-time", "Correctly caught " + e.reason );
+              te.update( { start: 1, end: "m" } );
+            } catch( e2 ) {
+              equal( e2.reason, "invalid-end-time", "Correctly caught " + e2.reason );
 
               try {
-                te.update( { start: 1, end: "m" } );
-              } catch( e2 ) {
-                equal( e2.reason, "invalid-end-time", "Correctly caught " + e2.reason );
+                te.update( { start: 10, end: 8 } );
+              } catch( e3 ) {
+                equal( e3.reason, "start-greater-than-end", "Correctly caught " + e3.reason );
 
-                try {
-                  te.update( { start: 10, end: 8 } );
-                } catch( e3 ) {
-                  equal( e3.reason, "start-greater-than-end", "Correctly caught " + e3.reason );
-
-                  start();
-                }
+                start();
               }
             }
-          });
+          }
         });
       });
     </script>


### PR DESCRIPTION
Fix tests that fail because of it.

One thing of note:
- Our Media instance never reports ready when using null Video, or never seemed to for the two test groups I needed to fix.
