### PR TITLE
[#2592] Prevent mouseup from firing blink on the track events target

### DIFF
--- a/src/timeline/media.js
+++ b/src/timeline/media.js
@@ -105,12 +105,6 @@ define( [ "core/trackevent", "core/track", "core/eventmanager",
     }
 
     function onTrackEventMouseUp( e ){
-      if( _currentMouseDownTrackEvent && _trackEventHighlight === "click" ){
-        var corn = _currentMouseDownTrackEvent.popcornOptions;
-        if( corn.target ){
-          blinkTarget( corn.target );
-        }
-      }
     }
 
     function onTrackEventDragStarted( e ){


### PR DESCRIPTION
https://webmademovies.lighthouseapp.com/projects/65733/tickets/2592-selecting-an-event-on-the-timeline-causes-a-brief-highlight-of-the-entire-video
