### PR TITLE
[#2707] Image editor overrides default editor, but forgets to reset erro...

### DIFF
--- a/templates/assets/editors/image/image-editor.js
+++ b/templates/assets/editors/image/image-editor.js
@@ -328,6 +328,7 @@
       _trackEvent = e.target;
       calcImageTime();
       _this.updatePropertiesFromManifest( _trackEvent );
+      _this.setErrorState( false );
 
       var links, i, ln,
           src = _trackEvent.popcornOptions.src;


### PR DESCRIPTION
...r states on a successful track event update( no errors )
