### PR TITLE
[#2752] Add Coda to our list of fonts being used from Google

### DIFF
--- a/src/editor/trackevent-editor.js
+++ b/src/editor/trackevent-editor.js
@@ -20,7 +20,8 @@ define([ "util/lang", "util/keys", "util/time", "./base-editor", "ui/widget/tool
         "Open Sans",
         "Bangers",
         "Fredoka One",
-        "Covered By Your Grace"
+        "Covered By Your Grace",
+        "Coda"
       ],
       __colorHexCodes = {
         "black": "#000000",
@@ -599,6 +600,8 @@ define([ "util/lang", "util/keys", "util/time", "./base-editor", "ui/widget/tool
           var font,
               m,
               fLen;
+
+          __googleFonts = __googleFonts.sort();
 
           for ( m = 0, fLen = __googleFonts.length; m < fLen; m++ ) {
             font = document.createElement( "option" );


### PR DESCRIPTION
https://webmademovies.lighthouseapp.com/projects/65733/tickets/2752-add-impact-or-derivative-as-a-supported-font-for-text-events
