### PR TITLE
Bug 2591 - Prepare projects to be fronted by the clouds

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ new file called _hostname_-_environment_.json that overrides the cornfield defau
     - `wwwRoot` the server's WWW root directory (e.g., `../`)
     - `templates` the location of templates (e.g., `../templates`)
     - `appHostname` the hostname URL for the application, usually the same as `server.bindIP` and `server.bindPort` (e.g., `http://localhost:8888`)
-    - `embedHostname` <i>[optional]</i> the hostname URL where published embed documents are stored, if different from `dirs.appHostname` (e.g., `http://s3.amazonaws.com/your-bucket`)
+    - `embedHostname` *[optional]* the hostname URL where published embed documents are stored, if different from `dirs.appHostname` (e.g., `http://s3.amazonaws.com/your-bucket`)
   - `templates` list of templates to serve.  The format is as follows:
     `<template-name>`: `{{templateBase}}<path/to/template/config.json>`.  The `{{templateBase}}` string will be replaced by the value in `dirs.templates` (e.g., "basic": "{{templateBase}}basic/config.json")
 
@@ -134,15 +134,16 @@ The `fileStore` type is used to setup a backend for storing data:
       - `hostname` the hostname to use for constructing urls if different than `embedHostname`
       - local options
          - `root` the root directory under which all exported files are placed (e.g., `./view`)
-         - `namePrefix` <i>[optional]</i> the path prefix to add to any filenames passed to the local file store.  For example, if using "v" all filenames will become "v/<key>"
-         - `nameSuffix` <i>[optional]</i> the filename suffix to use for all filenames (e.g., ".html")
+         - `namePrefix` *[optional]* the path prefix to add to any filenames passed to the local file store.  For example, if using "v" all filenames will become "v/<key>"
+         - `nameSuffix` *[optional]* the filename suffix to use for all filenames (e.g., ".html")
       - s3 options
        - `key` the AWS S3 key to use for authentication
        - `secret` the AWS S3 secret to use for authentication
        - `bucket` the AWS S3 bucket name to use for storing key/value pairs
-       - `namePrefix` <i>[optional]</i> the prefix to add to any key names passed to the s3 file store.  For example, if using "v" all keys will become "v/<key>"
-       - `nameSuffix` <i>[optional]</i> the suffix to add to any key names passed to the s3 file store.  For example, if using ".json" all keys will end in ".json"
-       - `contentType` <i>[optional]</i> the mime type to use for data written to S3. If none given `text/plain` is used.
+       - `namePrefix` *[optional]* the prefix to add to any key names passed to the s3 file store.  For example, if using "v" all keys will become "v/<key>"
+       - `nameSuffix` *[optional]* the suffix to add to any key names passed to the s3 file store.  For example, if using ".json" all keys will end in ".json"
+       - `contentType` *[optional]* the mime type to use for data written to S3. If none given `text/plain` is used.
+       - `headers` *[optional]* any additional headers to use for data written to S3. For example, setting cache control headers with `{ 'Cache-Control': 'max-age=1800' }`.
 
 #### ImageStore
 

--- a/cornfield/lib/file-store.js
+++ b/cornfield/lib/file-store.js
@@ -112,16 +112,27 @@ function S3FileStore( options ) {
 
   // If embedHostname isn't appropriate, a hostname can be provided to override it.
   this.hostname = options.hostname;
+
+  // Append any additional headers to send with a write request
+  if ( options.headers ) {
+    this.headers = options.headers;
+  }
 }
 
 S3FileStore.prototype = Object.create( BaseFileStore );
 
 S3FileStore.prototype.write = function( key, data, callback ) {
-  this.client.put( this.expand( key ), {
+  var headers = {
     'x-amz-acl': 'public-read',
     'Content-Length': data.length,
     'Content-Type': this.contentType
-  })
+  };
+
+  Object.keys( this.headers ).forEach(function( key ) {
+    headers[ key ] = this.headers[ key ];
+  });
+
+  this.client.put( this.expand( key ), headers )
   .on( 'response', function( res ) {
     if( res.statusCode === 200 ) {
       callback();

--- a/cornfield/views/embed-shell.jade
+++ b/cornfield/views/embed-shell.jade
@@ -21,4 +21,9 @@ html
     title #{projectName} - Popcorn Maker
     link(rel='stylesheet', href='#{baseHref}/css/embed-shell.css')
   body
-    iframe(src='#{embedSrc}', width='1280', height='745', mozallowfullscreen='mozallowfullscreen', webkitallowfullscreen='webkitallowfullscreen', allowfullscreen='allowfullscreen')
+    iframe(id='embed', src='#{embedSrc}', width='1280', height='745', mozallowfullscreen='mozallowfullscreen', webkitallowfullscreen='webkitallowfullscreen', allowfullscreen='allowfullscreen')
+    script
+      if ( location.search ) {
+        var embed = document.querySelector('#embed');
+        embed.src = embed.src + location.search;
+      }

--- a/src/core/project.js
+++ b/src/core/project.js
@@ -129,6 +129,13 @@ define( [ 'core/eventmanager', 'core/media' ],
         enumerable: true
       },
 
+      "previewUrl": {
+        get: function() {
+          return _publishUrl + "?previewTime=" + Date.now();
+        },
+        enumerable: true
+      },
+
       "iframeUrl": {
         get: function() {
           return _iframeUrl;

--- a/src/editor/share-editor.js
+++ b/src/editor/share-editor.js
@@ -32,7 +32,7 @@ define([ "editor/editor", "editor/base-editor",
     function togglePreviewButton( on ) {
       if ( on ) {
         previewBtn.classList.remove( "butter-disabled" );
-        previewBtn.href = butter.project.publishUrl;
+        previewBtn.href = butter.project.previewUrl;
         previewBtn.onclick = function() {
           return true;
         };

--- a/src/ui/header.js
+++ b/src/ui/header.js
@@ -33,7 +33,7 @@ define([ "dialog/dialog", "util/lang", "text!layouts/header.html", "ui/user-data
     });
 
     _this.element = _rootElement;
-    
+
     ToolTip.apply( _projectTitle );
 
     _tabzilla.addEventListener( "click", function() {
@@ -73,7 +73,7 @@ define([ "dialog/dialog", "util/lang", "text!layouts/header.html", "ui/user-data
     function togglePreviewButton( on ) {
       if ( on ) {
         _previewBtn.classList.remove( "butter-disabled" );
-        _previewBtn.href = butter.project.publishUrl;
+        _previewBtn.href = butter.project.previewUrl;
         _previewBtn.onclick = function() {
           return true;
         };
@@ -156,7 +156,7 @@ define([ "dialog/dialog", "util/lang", "text!layouts/header.html", "ui/user-data
     function onLogin() {
       _webmakerNav.views.login( butter.cornfield.username() );
     }
-    
+
     butter.listen( "autologinsucceeded", onLogin, false );
     butter.listen( "authenticated", onLogin, false );
     butter.listen( "logout", _webmakerNav.views.logout, false );


### PR DESCRIPTION
This patch prepares our S3 code to be put behind the CloudFront CDN service by:
- Providing cache-busting URLs to the share editor
- Passing cache-busting URLs through the embed shell to the embed
- Added configuration option to pass arbitrary headers to S3 when writing an object
- Documentation for the S3 changes
