### PR TITLE
[#2785] Make first run dialog wait for media, and not timeline data. If ...

### DIFF
--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -107,7 +107,7 @@ define( [ "core/eventmanager", "./toggler",
           // Spin-up the crash reporter
           CrashReporter.init( butter, _uiConfig );
 
-          butter.listen( "ready", FirstRun.init );
+          butter.listen( "mediaready", FirstRun.init );
 
           onReady();
         });


### PR DESCRIPTION
...we do not wait for media, the plugin list is not going to be ready, and thus we'll not have a popup plugin to point to. If the plugin list is open when timeline data is ready, it can cause a crash by dragging a pplugin to the timeline.
