### PR TITLE
[#2837] Media ready state flag is never set to false when media source c...

### DIFF
--- a/src/core/media.js
+++ b/src/core/media.js
@@ -450,6 +450,7 @@
           set: function( val ) {
             if ( _url !== val ) {
               _url = val;
+              _ready = false;
               _popcornWrapper.clear( _target );
               setupContent();
               _this.dispatch( "mediacontentchanged", _this );


### PR DESCRIPTION
...hanges

https://webmademovies.lighthouseapp.com/projects/65733-popcorn-maker/tickets/2837-loading-spinner-in-media-editor-doesnt-while-media-is-still-loading
