### PR TITLE
Bug 2857 - Fix embed shell CSS regression from bug #2845

### DIFF
--- a/css/embed-shell.less
+++ b/css/embed-shell.less
@@ -78,25 +78,29 @@ body > iframe {
 * Media queries
 */
 @media only screen and ( max-width: @medium ) {
-  .iframe-container, body > iframe {
+  .iframe-container,
+  body > iframe {
     .height-width( @small );
   }
 }
 
 @media only screen and ( min-width: @medium ) {
-  .iframe-container, body > iframe {
+  .iframe-container,
+  body > iframe {
     .height-width( @medium );
   }
 }
 
 @media only screen and ( min-width: @large ) {
-  .iframe-container, body > iframe {
+  .iframe-container,
+  body > iframe {
     .height-width( @large );
   }
 }
 
 @media only screen and ( min-width: @xlarge ) {
-  .iframe-container, body iframe {
+  .iframe-container,
+  body iframe {
     .height-width( @xlarge );
   }
 }

--- a/css/embed-shell.less
+++ b/css/embed-shell.less
@@ -58,38 +58,45 @@ body {
   position: relative;
 }
 
-iframe {
+.iframe-container > iframe {
   width: 100%;
   height: 100%;
+}
+
+iframe {
   border: 0;
   padding: 0;
   overflow: hidden;
   display: block;
 }
 
+body > iframe {
+  margin: 6em auto;
+}
+
 /*********************************************************
 * Media queries
 */
 @media only screen and ( max-width: @medium ) {
-  .iframe-container {
+  .iframe-container, body > iframe {
     .height-width( @small );
   }
 }
 
 @media only screen and ( min-width: @medium ) {
-  .iframe-container {
+  .iframe-container, body > iframe {
     .height-width( @medium );
   }
 }
 
 @media only screen and ( min-width: @large ) {
-  .iframe-container {
+  .iframe-container, body > iframe {
     .height-width( @large );
   }
 }
 
 @media only screen and ( min-width: @xlarge ) {
-  .iframe-container {
+  .iframe-container, body iframe {
     .height-width( @xlarge );
   }
 }


### PR DESCRIPTION
The HTML structure of the embed shell was changed in bug #2845 to include a
wrapper div for the iframe. The CSS was also updated to match this structure.
This meant that projects published before November 6th appear broken, since
they don't have width/height CSS selectors
