### PR TITLE
Bug 2857 - Fix embed shell CSS regression from bug #2845

### DIFF
--- a/cornfield/views/embed-shell.jade
+++ b/cornfield/views/embed-shell.jade
@@ -23,8 +23,7 @@ html
   body
     .preview-message This is a preview URL only. When sharing, please use the following URL: 
         a(href='#{embedShellSrc}') #{embedShellSrc}
-    .iframe-container
-        iframe(id='embed', src='#{embedSrc}', width='1280', height='745', mozallowfullscreen='mozallowfullscreen', webkitallowfullscreen='webkitallowfullscreen', allowfullscreen='allowfullscreen')
+    iframe(id='embed', src='#{embedSrc}', width='1280', height='745', mozallowfullscreen='mozallowfullscreen', webkitallowfullscreen='webkitallowfullscreen', allowfullscreen='allowfullscreen')
     script
       if ( location.search && location.search.search(/(\?|&)preview=true(&|$)/) > -1 ) {
         var embed = document.querySelector('#embed');

--- a/css/embed-shell.less
+++ b/css/embed-shell.less
@@ -53,11 +53,6 @@ body {
   }
 }
 
-.iframe-container {
-  margin: 6em auto;
-  position: relative;
-}
-
 iframe {
   width: 100%;
   height: 100%;
@@ -65,31 +60,32 @@ iframe {
   padding: 0;
   overflow: hidden;
   display: block;
+  margin: 6em auto;
 }
 
 /*********************************************************
 * Media queries
 */
 @media only screen and ( max-width: @medium ) {
-  .iframe-container {
+  iframe {
     .height-width( @small );
   }
 }
 
 @media only screen and ( min-width: @medium ) {
-  .iframe-container {
+  iframe {
     .height-width( @medium );
   }
 }
 
 @media only screen and ( min-width: @large ) {
-  .iframe-container {
+  iframe {
     .height-width( @large );
   }
 }
 
 @media only screen and ( min-width: @xlarge ) {
-  .iframe-container {
+  iframe {
     .height-width( @xlarge );
   }
 }


### PR DESCRIPTION
The HTML structure of the embed shell was changed in bug #2845 to include a
wrapper div for the iframe. The CSS was also updated to match this structure.
This meant that projects published before November 6th appear broken, since
they don't have width/height CSS selectors
