### PR TITLE
[#2898] alwaysFirst in query string triggers first run dialog.

### DIFF
--- a/src/first-run.js
+++ b/src/first-run.js
@@ -87,7 +87,7 @@ define( [ "dialog/dialog", "ui/widget/tooltip", "util/shims" ], function( Dialog
       try {
         var data = __butterStorage.getItem( "butter-first-run" );
 
-        if ( !data ) {
+        if ( !data || window.location.search.match( "forceFirstRun" ) ) {
           __butterStorage.setItem( "butter-first-run", true );
           setupFirstRun();
           dialog = Dialog.spawn( "first-run" );


### PR DESCRIPTION
Lighthouse ticket: https://webmademovies.lighthouseapp.com/projects/65733-popcorn-maker/tickets/2898-re-add-alwaysfirst-flag-to-force-first-run-stuff
