### PR TITLE
[#2900]

### DIFF
--- a/src/editor/header.js
+++ b/src/editor/header.js
@@ -65,9 +65,12 @@ define([ "ui/widget/tooltip",
     };
 
     Object.defineProperty( this, "focusMap", {
+      enumerable: true,
       writeable: false,
       configurable: false,
-      value: _focusMap
+      get: function() {
+        return _focusMap;
+      }
     });
 
     this.views = {

--- a/src/editor/header.js
+++ b/src/editor/header.js
@@ -14,7 +14,7 @@ define([ "ui/widget/tooltip",
         _waitForMediaTooltip;
 
     var _focusMap = {
-      "media-properties": _mediaButton,
+      "media-editor": _mediaButton,
       "plugin-list": _popcornButton,
       "share-properties": _shareButton
     };
@@ -63,6 +63,12 @@ define([ "ui/widget/tooltip",
         _currentFocus = focusCandidate;
       }
     };
+
+    Object.defineProperty( this, "focusMap", {
+      writeable: false,
+      configurable: false,
+      value: _focusMap
+    });
 
     this.views = {
       unSaved: function() {

--- a/src/editor/media-editor.js
+++ b/src/editor/media-editor.js
@@ -224,7 +224,6 @@ define( [ "util/lang", "util/uri", "util/keys", "editor/editor", "text!layouts/m
         }
 
         setup();
-        document.querySelector( ".butter-editor-header-media" ).classList.add( "butter-active" );
       },
       close: function() {
         _media.unlisten( "mediaready", onMediaReady );

--- a/src/editor/module.js
+++ b/src/editor/module.js
@@ -101,7 +101,14 @@ define( [ "core/eventmanager", "core/trackevent", "./editor",
         _this.openEditor( DEFAULT_EDITOR_NAME );
       });
 
-      _header.setFocus( editorName );
+      // Check if this is a top-level editor
+      if ( _header.focusMap[ editorName ] ) {
+        _header.setFocus( editorName );
+      } else {
+        // Otherwise, it is an event editor, so focus the default editor
+        _header.setFocus( DEFAULT_EDITOR_NAME );
+      }
+
 
       // If the editor was closed when this was called, remove classes keeping it hidden
       if ( _editorAreaDOMRoot.classList.contains( "minimized" ) ) {
@@ -220,14 +227,14 @@ define( [ "core/eventmanager", "core/trackevent", "./editor",
           }
 
           LangUtils.applyTransitionEndListener( _editorAreaDOMRoot, onTransitionEnd );
-          
+
         }, "Show/Hide Editor", true );
 
       var editorsToLoad = [],
           editorsLoaded = 0;
 
       if ( butter.config.value( "ui" ).enabled !== false ) {
- 
+
         // Set up views for share editor
         butter.listen( "ready", setupHeader );
         butter.listen( "autologinsucceeded", setupHeader );
@@ -262,7 +269,7 @@ define( [ "core/eventmanager", "core/trackevent", "./editor",
             Editor.initialize( onModuleReady, butter.config.value( "baseDir" ) );
           }, function( e ) {
             _logger.log( "Couldn't load editor " + e.target.src );
-            
+
             if ( ++editorsLoaded === editorsToLoad.length ) {
               onModuleReady();
             }


### PR DESCRIPTION
1. Force focus on the default editor when not using the media or share editors.
2. Fixed hidden bug where the media editor was manually switching focus, we had mapped the wrong name in header.js

Lighthouse Ticket: https://webmademovies.lighthouseapp.com/projects/65733/tickets/2900-should-the-events-button-remain-highlighted-when-in-an-track-event-editor
