### PR TITLE
[#2950] Editors close when track event is deselected. Also, editors open...

### DIFF
--- a/src/timeline/media.js
+++ b/src/timeline/media.js
@@ -151,8 +151,8 @@ define( [ "core/trackevent", "core/track", "core/eventmanager",
       function onTrackEventAdded( e ){
         var trackEvent = e.data;
         trackEvent.view.listen( "trackeventmousedown", onTrackEventMouseDown );
-        trackEvent.listen( "trackeventselected", onTrackEventSelected);
-        trackEvent.listen( "trackeventdeselected", onTrackEventDeselected);
+        trackEvent.listen( "trackeventselected", onTrackEventSelected );
+        trackEvent.listen( "trackeventdeselected", onTrackEventDeselected );
       }
 
       function onTrackAdded( e ){

--- a/src/timeline/media.js
+++ b/src/timeline/media.js
@@ -114,6 +114,14 @@ define( [ "core/trackevent", "core/track", "core/eventmanager",
       window.addEventListener( "mousemove", onTrackEventDragStarted, false );
     }
 
+    function onTrackEventSelected( e ) {
+      butter.editor.editTrackEvent( e.target );
+    }
+
+    function onTrackEventDeselected( e ) {
+      butter.editor.closeTrackEventEditor( e.target );
+    }
+
     function onMediaReady(){
       _bounds = DEFAULT_BOUNDS;
       _tracksContainer.setViewportBounds( _bounds[ 0 ], _bounds[ 1 ] );
@@ -136,14 +144,15 @@ define( [ "core/trackevent", "core/track", "core/eventmanager",
       _media.listen( "trackeventremoved", function( e ){
         var trackEvent = e.data;
         trackEvent.view.unlisten( "trackeventmousedown", onTrackEventMouseDown );
+        trackEvent.unlisten( "trackeventselected", onTrackEventSelected );
+        trackEvent.unlisten( "trackeventdeselected", onTrackEventDeselected );
       });
 
       function onTrackEventAdded( e ){
         var trackEvent = e.data;
         trackEvent.view.listen( "trackeventmousedown", onTrackEventMouseDown );
-        trackEvent.view.element.addEventListener( "click", function( e ) {
-          butter.editor.editTrackEvent( trackEvent );
-        });
+        trackEvent.listen( "trackeventselected", onTrackEventSelected);
+        trackEvent.listen( "trackeventdeselected", onTrackEventDeselected);
       }
 
       function onTrackAdded( e ){


### PR DESCRIPTION
... when selected, and not just when clicked. Example, tab changes the active editor/closes it now too.
