### PR TITLE
[#1912] Ensure the first run init function runs only once

### DIFF
--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -107,7 +107,12 @@ define( [ "core/eventmanager", "./toggler",
           // Spin-up the crash reporter
           CrashReporter.init( butter, _uiConfig );
 
-          butter.listen( "mediaready", FirstRun.init );
+          function firstRunInit() {
+            butter.unlisten( "mediaready", firstRunInit );
+            FirstRun.init();
+          }
+
+          butter.listen( "mediaready", firstRunInit );
 
           onReady();
         });


### PR DESCRIPTION
https://webmademovies.lighthouseapp.com/projects/65733/tickets/2912-crash-cannot-call-method-destroy-of-null-dialogjs-line-293
