### PR TITLE
[#2960] Dialog wasn't passing the dialogs name into it's spawn function

### DIFF
--- a/src/dialog/dialog.js
+++ b/src/dialog/dialog.js
@@ -360,7 +360,7 @@ define( [ "util/lang", "core/eventmanager", "./modal" ],
      * @param {Function} dialogCtor: Function to be run after dialog internals are in place
      */
     register: function( name, layoutSrc, dialogCtor ) {
-      __dialogs[ name ] = __createDialog( layoutSrc, dialogCtor );
+      __dialogs[ name ] = __createDialog( layoutSrc, dialogCtor, name );
       __openDialogs[ name ] = false;
     },
 


### PR DESCRIPTION
https://webmademovies.lighthouseapp.com/projects/65733/tickets/2960-crash-reporter-unable-to-catch-errors-in-dialog-code-andor-dialog-event-callbacks
