### PR TITLE
[#2970] Make link tags with data-butter-exclude be parsed by cornfield.

### DIFF
--- a/cornfield/app.js
+++ b/cornfield/app.js
@@ -187,8 +187,8 @@ app.post( '/api/publish/:id',
       baseHref = APP_HOSTNAME + templateURL + "/";
       baseString = '\n  <base href="' + baseHref + '"/>';
 
-      // look for script tags with data-butter-exclude in particular (e.g. butter's js script)
-      data = data.replace( /\s*<script[\.\/='":_\-\w\s]*data-butter-exclude[\.\/='":_\-\w\s]*><\/script>/g, '' );
+      // look for script and link tags with data-butter-exclude in particular (e.g. butter's js script)
+      data = data.replace( /\s*<(script|link)[\.\/='":_\-\w\s]*data-butter-exclude[\.\/='":_\-\w\s]*>(<\/script>)?/g, '' );
 
       // Adding  to cut out the actual head tag
       headStartTagIndex = data.indexOf( '<head>' ) + 6;

--- a/templates/basic/index.html
+++ b/templates/basic/index.html
@@ -9,7 +9,7 @@
   <meta name="viewport" content="width=device-width">
 
   <link rel="stylesheet" href="style.css">
-  <link rel="stylesheet" href="../assets/css/jquery-ui/jquery.ui.butter.css">
+  <link rel="stylesheet" href="../assets/css/jquery-ui/jquery.ui.butter.css" data-butter-exclude>
 
   <link rel="stylesheet" href="../../../css/transitions.css">
   <link rel="stylesheet" href="../assets/plugins/popup/popcorn.popup.css">
@@ -18,11 +18,11 @@
   <link rel="stylesheet" href="../assets/plugins/text/popcorn.text.css">
   <link rel="stylesheet" href="../assets/plugins/wikipedia/popcorn.wikipedia.css">
 
-  <link href="//www.mozilla.org/tabzilla/media/css/tabzilla.css" rel="stylesheet">
+  <link href="//www.mozilla.org/tabzilla/media/css/tabzilla.css" rel="stylesheet" data-butter-exclude>
 
   <script src="../../src/butter.js" data-butter-exclude></script>
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
-  <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.9.1/jquery-ui.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js" data-butter-exclude></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.9.1/jquery-ui.min.js" data-butter-exclude></script>
   <script src="../assets/editors/editorhelper.js" data-butter-exclude></script>
   <script src="../assets/editors/wikipedia.js" data-butter-exclude></script>
   <script src="../assets/editors/popup/popup.js" data-butter-exclude></script>


### PR DESCRIPTION
Add this attribute to missing elements in the basic template
