### PR TITLE
[#2923] Add a 0.05 second allowance for trackevent end values, to cover ...

### DIFF
--- a/src/core/media.js
+++ b/src/core/media.js
@@ -405,9 +405,15 @@
             end = trackEventOptions.end;
 
             // check if track event if out of bounds
-            if ( end > _duration  ) {
-              // remove offending track event
-              trackEvent.track.removeTrackEvent( trackEvent );
+            if ( end > _duration ) {
+              if ( start > _duration ) {
+                // remove offending track event
+                trackEvent.track.removeTrackEvent( trackEvent );
+              } else {
+                trackEvent.update({
+                  end: _duration
+                });
+              }
             }
           }
         }


### PR DESCRIPTION
...for differences in duration of medias across browsers/systems. This prevents the removal of previously valid events which get removed in error

Lighthouse Ticket: https://webmademovies.lighthouseapp.com/projects/65733-popcorn-maker/tickets/2923
