### PR TITLE
added CSS transition for the post-roll container - 1s delay, 1s fadein

### DIFF
--- a/css/embed.less
+++ b/css/embed.less
@@ -341,7 +341,17 @@ body {
   left: 0;
   width: 100%;
   height: 100%;
-  display: none;
+  display: block;
+  opacity: 0;
+
+  // No transition from "visible" to "invisible"
+  .transition( none );
+
+  &.embed-dialog-open {
+    opacity: 1;
+    // Fade-in transition from "invisible" to visible"
+    .transition( opacity 1s ease 1s );
+  }
 }
 
 #post-roll,
@@ -471,6 +481,7 @@ body {
   }
 
 } // post-roll
+
 
 
 /*********************************************************

--- a/src/embed.js
+++ b/src/embed.js
@@ -79,9 +79,9 @@ function init() {
       popcorn.pause();
     }
 
-    addStateClass( "embed-dialog-open" );
+    setStateClass( "embed-dialog-open" );
     hide( "#controls-big-play-button" );
-    hide( "#post-roll-container" );
+    clearStateClass();
     show( "#share-container" );
   }
 
@@ -136,18 +136,26 @@ function init() {
     return "";
   }
 
-  function addStateClass( state ) {
+  // indicate which state the post roll is in
+  function setStateClass( state ) {
     var el = $( "#post-roll-container" );
 
     if ( el.classList.contains( state ) ) {
       return;
     }
 
+    clearStateClass( el );
+
+    el.classList.add( state );
+  }
+
+  // clear the state class indicator for the post roll container
+  function clearStateClass( el ) {
+    var el = el || $( "#post-roll-container" );
+
     for ( var i = 0; i < stateClasses.length; i++ ) {
       el.classList.remove( stateClasses[ i ] );
     }
-
-    el.classList.add( state );
   }
 
   function setupEventHandlers( popcorn, config ) {
@@ -159,7 +167,7 @@ function init() {
 
       // If the video is done, go back to the postroll
       if ( popcorn.ended() ) {
-        show( "#post-roll-container" );
+        setStateClass( "embed-dialog-open" );
       }
     }, false );
 
@@ -175,23 +183,21 @@ function init() {
     }
 
     popcorn.on( "ended", function() {
-      show( "#post-roll-container" );
-      addStateClass( "embed-dialog-open" );
+      setStateClass( "embed-dialog-open" );
     });
 
     popcorn.on( "pause", function() {
       if ( hideInfoDiv ) {
-        addStateClass( "embed-dialog-open" );
+        setStateClass( "embed-dialog-open" );
         hideInfoDiv = false;
       } else {
-        addStateClass( "embed-paused" );
+        setStateClass( "embed-paused" );
       }
     });
 
     popcorn.on( "playing", function() {
       hide( "#share-container" );
-      hide( "#post-roll-container" );
-      addStateClass( "embed-playing" );
+      setStateClass( "embed-playing" );
     });
 
     function onCanPlay() {


### PR DESCRIPTION
also modified embed.js to not use show() and hide() for the post roll container, because they flip display:block and display:none, which clobbers CSS transitions completely. I only refactored this for the post roll container, but I'll file an issue to refactor them out of existence.
