### PR TITLE
[#2831] prevent accidental navigation on delete/backspace

### DIFF
--- a/src/ui/ui.js
+++ b/src/ui/ui.js
@@ -452,8 +452,9 @@ define( [ "core/eventmanager", "./toggler",
             dialog,
             i, l = selectedEvents.length;
 
+        e.preventDefault();
+
         if( selectedEvents.length ) {
-          e.preventDefault();
 
           // If any event is being dragged or resized we don't want to
           // allow deletion.


### PR DESCRIPTION
https://webmademovies.lighthouseapp.com/projects/65733-popcorn-maker/tickets/2831-delete-key-disabled-except-for-things-that-have-focus#ticket-2831-4
