### PR TITLE
bug 3229 - made cornfield form URLs with / instead of \ when run on Windows

### DIFF
--- a/cornfield/app.js
+++ b/cornfield/app.js
@@ -104,12 +104,6 @@ require( 'express-persona' )( app, {
 
 require('./routes')( app, User, filter, sanitizer, stores, utils, metrics );
 
-// Converter for paths, which may either use \ or / as
-// delimiter, to URLs, which must use / as delimiter.
-function pathToURL( s ) {
-  return s.replace( /\\/g, '/' );
-}
-
 function writeEmbedShell( path, url, data, callback ) {
   if( !writeEmbedShell.templateFn ) {
     writeEmbedShell.templateFn = jade.compile( fs.readFileSync( 'views/embed-shell.jade', 'utf8' ),
@@ -204,7 +198,7 @@ app.post( '/api/publish/:id',
 
       externalAssetsString += '\n';
       for ( i = 0; i < EXPORT_ASSETS.length; ++i ) {
-        externalAssetURL = pathToURL( path.relative( path.dirname( templateFile ), EXPORT_ASSETS[ i ] ) );
+        externalAssetURL = utils.pathToURL( path.relative( path.dirname( templateFile ), EXPORT_ASSETS[ i ] ) );
         externalAssetsString += '  <script src="' + externalAssetURL + '"></script>\n';
       }
 
@@ -212,7 +206,7 @@ app.post( '/api/publish/:id',
       if ( templateConfig.plugin && templateConfig.plugin.plugins ) {
         var plugins = templateConfig.plugin.plugins;
         for ( i = 0, len = plugins.length; i < len; i++ ) {
-          externalAssetURL = pathToURL( APP_HOSTNAME + '/' + plugins[ i ].path.split( '{{baseDir}}' ).pop() );
+          externalAssetURL = utils.pathToURL( APP_HOSTNAME + '/' + plugins[ i ].path.split( '{{baseDir}}' ).pop() );
           externalAssetsString += '\n  <script src="' + externalAssetURL + '"></script>';
         }
         externalAssetsString += '\n';
@@ -330,7 +324,7 @@ app.get( '/dashboard', filter.isStorageAvailable, function( req, res ) {
           _id: String(project.id),
           name: sanitizer.escapeHTML( project.name ),
           template: project.template,
-          href: pathToURL( path.relative( WWW_ROOT, templateConfigs[ project.template ].template ) +
+          href: utils.pathToURL( path.relative( WWW_ROOT, templateConfigs[ project.template ].template ) +
             "?savedDataUrl=/api/project/" + project.id ),
           updatedAt: project.updatedAt
         });

--- a/cornfield/app.js
+++ b/cornfield/app.js
@@ -184,7 +184,7 @@ app.post( '/api/publish/:id',
       // Converter for paths, which may either use \ or / as
       // delimiter, to URLs, which must use / as delimiter.
       function pathToURL( s ) {
-        return s.replace(/\\/g,'/');
+        return s.replace( /\\/g, '/' );
       }
 
       templateURL = templateFile.substring( templateFile.indexOf( '/templates' ), templateFile.lastIndexOf( '/' ) );

--- a/cornfield/app.js
+++ b/cornfield/app.js
@@ -104,6 +104,12 @@ require( 'express-persona' )( app, {
 
 require('./routes')( app, User, filter, sanitizer, stores, utils, metrics );
 
+// Converter for paths, which may either use \ or / as
+// delimiter, to URLs, which must use / as delimiter.
+function pathToURL( s ) {
+  return s.replace( /\\/g, '/' );
+}
+
 function writeEmbedShell( path, url, data, callback ) {
   if( !writeEmbedShell.templateFn ) {
     writeEmbedShell.templateFn = jade.compile( fs.readFileSync( 'views/embed-shell.jade', 'utf8' ),
@@ -180,12 +186,6 @@ app.post( '/api/publish/:id',
           startString,
           numSources,
           j, k, len;
-
-      // Converter for paths, which may either use \ or / as
-      // delimiter, to URLs, which must use / as delimiter.
-      function pathToURL( s ) {
-        return s.replace( /\\/g, '/' );
-      }
 
       templateURL = templateFile.substring( templateFile.indexOf( '/templates' ), templateFile.lastIndexOf( '/' ) );
       baseHref = APP_HOSTNAME + templateURL + "/";
@@ -330,8 +330,8 @@ app.get( '/dashboard', filter.isStorageAvailable, function( req, res ) {
           _id: String(project.id),
           name: sanitizer.escapeHTML( project.name ),
           template: project.template,
-          href: (path.relative( WWW_ROOT, templateConfigs[ project.template ].template ) +
-            "?savedDataUrl=/api/project/" + project.id).replace("\\","/"),
+          href: pathToURL( path.relative( WWW_ROOT, templateConfigs[ project.template ].template ) +
+            "?savedDataUrl=/api/project/" + project.id ),
           updatedAt: project.updatedAt
         });
       }

--- a/cornfield/lib/utils.js
+++ b/cornfield/lib/utils.js
@@ -7,22 +7,27 @@ var utils,
     CONSTANTS;
 
 utils = {
+  // Converter for paths, which may either use \ or / as
+  // delimiter, to URLs, which must use / as delimiter.
+  pathToURL: function ( s ) {
+    return s.replace( /\\/g, '/' );
+  },
   generateDataURIPair: function() {
     var filename = uuid.v4();
     return {
       filename: filename,
-      url: ( stores.images.hostname || CONSTANTS.EMBED_HOSTNAME ) +
-        '/' + stores.images.expand( filename )
+      url: utils.pathToURL( (stores.images.hostname || CONSTANTS.EMBED_HOSTNAME ) +
+           '/' + stores.images.expand( filename ) )
     };
   },
   generatePublishUrl: function( id ) {
-    return ( stores.publish.hostname || CONSTANTS.EMBED_HOSTNAME ) +
-      '/' + stores.publish.expand( utils.generateIdString( id ) );
+    return utils.pathToURL( ( stores.publish.hostname || CONSTANTS.EMBED_HOSTNAME ) +
+      '/' + stores.publish.expand( utils.generateIdString( id ) ) );
   },
   generateIframeUrl: function( id ) {
-    return ( stores.publish.hostname || CONSTANTS.EMBED_HOSTNAME ) +
+    return utils.pathToURL( ( stores.publish.hostname || CONSTANTS.EMBED_HOSTNAME ) +
       '/' + stores.publish.expand( utils.generateIdString( id ) +
-      CONSTANTS.EMBED_SUFFIX );
+      CONSTANTS.EMBED_SUFFIX ) );
   },
   generateIdString: function( id ) {
     return id.toString( 36 );


### PR DESCRIPTION
added a corrective function that ensures URLs don't use OS-specific path delimiters, but always use /
