### PR TITLE
[t3071] made descenders visible in post-roll

### DIFF
--- a/css/embed.less
+++ b/css/embed.less
@@ -394,7 +394,7 @@ body {
     font-size: 32px;
     font-weight: 700;
     color: #676867;
-    line-height: 1em;
+    line-height: 1.4em;
     max-width: 90%;
     overflow: hidden;
     white-space: nowrap;


### PR DESCRIPTION
increased the line-height for the postroll embed-title class, ticket at https://webmademovies.lighthouseapp.com/projects/65733/tickets/3071
