### PR TITLE
Bug #3305 - Have embed.js load Popcorn via require

### DIFF
--- a/cornfield/app.js
+++ b/cornfield/app.js
@@ -28,8 +28,7 @@ var express = require('express'),
     APP_HOSTNAME = stripSlash( CONFIG.dirs.appHostname ),
     // If a separate hostname is given for embed, use it, otherwise use app's hostname
     WWW_ROOT = path.resolve( CONFIG.dirs.wwwRoot || path.join( __dirname, ".." ) ),
-    VALID_TEMPLATES = CONFIG.templates,
-    EXPORT_ASSETS = CONFIG.exportAssets;
+    VALID_TEMPLATES = CONFIG.templates;
 
 var templateConfigs = {};
 
@@ -196,12 +195,6 @@ app.post( '/api/publish/:id',
       templateScripts = data.substring( headStartTagIndex, headEndTagIndex );
       startString = data.substring( 0, headStartTagIndex );
 
-      externalAssetsString += '\n';
-      for ( i = 0; i < EXPORT_ASSETS.length; ++i ) {
-        externalAssetURL = utils.pathToURL( path.relative( path.dirname( templateFile ), EXPORT_ASSETS[ i ] ) );
-        externalAssetsString += '  <script src="' + externalAssetURL + '"></script>\n';
-      }
-
       // If the template has custom plugins defined in it's config, add them to our exported page
       if ( templateConfig.plugin && templateConfig.plugin.plugins ) {
         var plugins = templateConfig.plugin.plugins;
@@ -233,7 +226,8 @@ app.post( '/api/publish/:id',
         }
         mediaUrlsString += mediaUrls[ numSources - 1 ] + '" ]';
 
-        popcornString += '\n(function(){';
+        // src/embed.js initializes Popcorn by executing the global popcornDataFn()
+        popcornString += '\nvar popcornDataFn = function(){';
         popcornString += '\nvar popcorn = Popcorn.smart("#' + currentMedia.target + '", ' +
                          mediaUrlsString + ', ' + JSON.stringify( mediaPopcornOptions ) + ');';
         for ( j = 0; j < currentMedia.tracks.length; ++ j ) {
@@ -245,7 +239,7 @@ app.post( '/api/publish/:id',
             popcornString += ');';
           }
         }
-        popcornString += '}());\n';
+        popcornString += '};\n';
       }
       popcornString += '</script>\n';
 
@@ -296,9 +290,7 @@ app.post( '/api/publish/:id',
                     remixUrl: remixUrl,
                     templateScripts: templateScripts,
                     externalAssets: externalAssetsString,
-                    // XXX: need a better way to wrap function, DOM needs to be ready
-                    popcorn: popcornString.replace( /^\(function\(\)\{/m, "Popcorn( function(){" )
-                                          .replace( /\}\(\)\);$/m, "});" )
+                    popcorn: popcornString
                   },
                   publishEmbedShell );
 

--- a/cornfield/config/default.json
+++ b/cornfield/config/default.json
@@ -52,30 +52,6 @@
   "templates": {
     "basic": "{{templateBase}}basic/config.json"
   },
-  "exportAssets": [
-    "../external/popcorn-js/ie8/popcorn.ie8.js",
-    "../external/popcorn-js/popcorn.js",
-    "../external/popcorn-js/wrappers/common/popcorn._MediaElementProto.js",
-    "../external/popcorn-js/wrappers/html5/popcorn.HTMLMediaElement.js",
-    "../external/popcorn-js/wrappers/null/popcorn.HTMLNullVideoElement.js",
-    "../external/popcorn-js/wrappers/soundcloud/popcorn.HTMLSoundCloudAudioElement.js",
-    "../external/popcorn-js/wrappers/vimeo/popcorn.HTMLVimeoVideoElement.js",
-    "../external/popcorn-js/wrappers/youtube/popcorn.HTMLYouTubeVideoElement.js",
-    "../external/popcorn-js/modules/player/popcorn.player.js",
-    "../external/popcorn-js/players/youtube/popcorn.youtube.js",
-    "../external/popcorn-js/players/vimeo/popcorn.vimeo.js",
-    "../external/popcorn-js/players/soundcloud/popcorn.soundcloud.js",
-    "../templates/assets/plugins/text/popcorn.text.js",
-    "../templates/assets/plugins/popup/popcorn.popup.js",
-    "../templates/assets/plugins/googlemap/popcorn.googlemap.js",
-    "../templates/assets/plugins/twitter/popcorn.twitter.js",
-    "../templates/assets/plugins/image/popcorn.image.js",
-    "../templates/assets/plugins/loopPlugin/popcorn.loopPlugin.js",
-    "../templates/assets/plugins/skip/popcorn.skip.js",
-    "../templates/assets/plugins/pausePlugin/popcorn.pausePlugin.js",
-    "../templates/assets/plugins/wikipedia/popcorn.wikipedia.js",
-    "../templates/assets/plugins/sequencer/popcorn.sequencer.js"
-  ],
   "database": {
     "database": "popcorn",
     "username": null,

--- a/cornfield/config/production.json
+++ b/cornfield/config/production.json
@@ -2,8 +2,5 @@
   "dirs": {
     "wwwRoot": "../public",
     "templates": "../public/templates"
-  },
-  "exportAssets": [
-    "../external/popcorn-js/popcorn.js"
-  ]
+  }
 }

--- a/make.js
+++ b/make.js
@@ -426,7 +426,7 @@ function buildJS( version, compress ){
   }
   stampVersion( version, 'dist/src/butter.js' );
 
-  result = exec(RJS + ' -o tools/embed.js ' + doCompress, {silent: true});
+  result = exec(RJS + ' -o tools/build-embed.js ' + doCompress, {silent: true});
   if (!!result.code) {
     echo(result.output);
   }

--- a/src/embed.js
+++ b/src/embed.js
@@ -1,4 +1,8 @@
-function init( window, document ) {
+/*! This Source Code Form is subject to the terms of the MIT license
+ *  If a copy of the MIT license was not distributed with this file, you can
+ *  obtain one at https://raw.github.com/mozilla/butter/master/LICENSE */
+
+function init() {
 
   var stateClasses = [
     "embed-playing",
@@ -242,21 +246,105 @@ function init( window, document ) {
   }
 
   var require = requirejs.config({
-    context: "embed",
     baseUrl: "/src",
+    // Paths are aliases to other modules
     paths: {
-      text: "../external/require/text"
+      // Core
+      "popcorn": "../external/popcorn-js/popcorn",
+      "popcorn.ie8": "../external/popcorn-js/ie8/popcorn.ie8",
+
+      // Wrappers
+      "popcorn._MediaElementProto": "../external/popcorn-js/wrappers/common/popcorn._MediaElementProto",
+      "popcorn.HTMLMediaElement": "../external/popcorn-js/wrappers/html5/popcorn.HTMLMediaElement",
+      "popcorn.HTMLNullVideoElement": "../external/popcorn-js/wrappers/null/popcorn.HTMLNullVideoElement",
+      "popcorn.HTMLSoundCloudAudioElement": "../external/popcorn-js/wrappers/soundcloud/popcorn.HTMLSoundCloudAudioElement",
+      "popcorn.HTMLVimeoVideoElement": "../external/popcorn-js/wrappers/vimeo/popcorn.HTMLVimeoVideoElement",
+      "popcorn.HTMLYouTubeVideoElement": "../external/popcorn-js/wrappers/youtube/popcorn.HTMLYouTubeVideoElement",
+
+      // Players
+      "popcorn.player": "../external/popcorn-js/modules/player/popcorn.player",
+      "popcorn.youtube": "../external/popcorn-js/players/youtube/popcorn.youtube",
+      "popcorn.vimeo": "../external/popcorn-js/players/vimeo/popcorn.vimeo",
+      "popcorn.soundcloud": "../external/popcorn-js/players/soundcloud/popcorn.soundcloud",
+
+      // Plugins
+      "popcorn.googlemap": "../templates/assets/plugins/googlemap/popcorn.googlemap",
+      "popcorn.image": "../templates/assets/plugins/image/popcorn.image",
+      "popcorn.loopPlugin": "../templates/assets/plugins/loopPlugin/popcorn.loopPlugin",
+      "popcorn.pausePlugin": "../templates/assets/plugins/pausePlugin/popcorn.pausePlugin",
+      "popcorn.popup": "../templates/assets/plugins/popup/popcorn.popup",
+      "popcorn.sequencer": "../templates/assets/plugins/sequencer/popcorn.sequencer",
+      "popcorn.skip": "../templates/assets/plugins/skip/popcorn.skip",
+      "popcorn.text": "../templates/assets/plugins/text/popcorn.text",
+      "popcorn.twitter": "../templates/assets/plugins/twitter/popcorn.twitter",
+      "popcorn.wikipedia": "../templates/assets/plugins/wikipedia/popcorn.wikipedia",
+
+      // RequireJS
+      "text": "../external/require/text"
+    },
+    // shim config defines dependencies between non-AMD modules, which is all of the Popcorn code
+    shim: {
+      // Core
+      "popcorn": [ "popcorn.ie8" ],
+
+      // Wrappers
+      "popcorn._MediaElementProto": [ "popcorn" ],
+      "popcorn.HTMLMediaElement": [ "popcorn" ],
+      "popcorn.HTMLNullVideoElement": [ "popcorn", "popcorn._MediaElementProto" ],
+      "popcorn.HTMLSoundCloudAudioElement": [ "popcorn", "popcorn._MediaElementProto" ],
+      "popcorn.HTMLVimeoVideoElement": [ "popcorn", "popcorn._MediaElementProto" ],
+      "popcorn.HTMLYouTubeVideoElement": [ "popcorn", "popcorn._MediaElementProto" ],
+
+      // Players
+      "popcorn.player": [ "popcorn" ],
+      "popcorn.soundcloud": [ "popcorn", "popcorn.player", "popcorn.HTMLSoundCloudAudioElement" ],
+      "popcorn.vimeo":  [ "popcorn", "popcorn.player", "popcorn.HTMLVimeoVideoElement" ],
+      "popcorn.youtube":  [ "popcorn", "popcorn.player", "popcorn.HTMLYouTubeVideoElement" ],
+
+      // Plugins
+      "popcorn.googlemap": [ "popcorn" ],
+      "popcorn.image": [ "popcorn" ],
+      "popcorn.loopPlugin": [ "popcorn" ],
+      "popcorn.pausePlugin": [ "popcorn" ],
+      "popcorn.popup": [ "popcorn"],
+      "popcorn.sequencer": [ "popcorn", "popcorn.player" ],
+      "popcorn.skip": [ "popcorn" ],
+      "popcorn.text": [ "popcorn" ],
+      "popcorn.twitter": [ "popcorn" ],
+      "popcorn.wikipedia": [ "popcorn" ]
     }
   });
 
-  require([
+  define("embed-main",
+    [
       "util/uri",
       "ui/widget/controls",
       "ui/widget/textbox",
-      // keep this at the end so it doesn't need a spot in the function signature
-      "util/shims"
+
+      // We must list all of the popcorn files that get used
+      // shim config will handle dependency order
+      "popcorn.soundcloud",
+      "popcorn.vimeo",
+      "popcorn.youtube",
+      "popcorn.googlemap",
+      "popcorn.image",
+      "popcorn.loopPlugin",
+      "popcorn.pausePlugin",
+      "popcorn.popup",
+      "popcorn.sequencer",
+      "popcorn.skip",
+      "popcorn.text",
+      "popcorn.twitter",
+      "popcorn.wikipedia",
+      "popcorn.HTMLMediaElement",
+      "popcorn.HTMLNullVideoElement",
+      "popcorn.HTMLSoundCloudAudioElement",
+      "popcorn.HTMLVimeoVideoElement",
+      "popcorn.HTMLYouTubeVideoElement"
     ],
     function( URI, Controls, TextboxWrapper ) {
+      // cornfield writes out the Popcorn initialization code as popcornDataFn()
+      window.popcornDataFn();
       /**
        * Expose Butter so we can get version info out of the iframe doc's embed.
        * This "butter" is never meant to live in a page with the full "butter".
@@ -408,15 +496,22 @@ function init( window, document ) {
       window.Butter = Butter;
     }
   );
+
+  require(["util/shims"], function() {
+    require(["embed-main"]);
+  });
 }
 
 document.addEventListener( "DOMContentLoaded", function() {
   // Source tree case vs. require-built case.
   if ( typeof require === "undefined" ) {
-    Popcorn.getScript( "../../external/require/require.js", function() {
-      init( window, window.document );
-    });
+    var rscript = document.createElement( "script" );
+    rscript.onload = function() {
+      init();
+    };
+    rscript.src = "/external/require/require.js";
+    document.head.appendChild( rscript );
   } else {
-    init( window, window.document );
+    init();
   }
 }, false );

--- a/tools/build-embed.js
+++ b/tools/build-embed.js
@@ -7,10 +7,6 @@
   // Where to find the module names listed below.
   baseUrl: '../src',
 
-  paths: {
-    'text': '../external/require/text'
-  },
-
   // Target the AMD loader shim as the main module to optimize,
   // so it shows up first in the built file,
   // since the embed modules use the define/require APIs that the almond
@@ -22,7 +18,11 @@
 
   // Files to include along with almond. Their nested dependencies will also be
   // included.
-  include: [ 'embed' ],
+  include: [ 'embed', 'embed-main' ],
+
+  // Have the analyzer include the requirejs config from that particular file
+  // Must be kept in sync with baseUrl + include
+  mainConfigFile: '../src/embed.js',
 
   // Wraps Butter in a closure and adds license information
   wrap: {


### PR DESCRIPTION
This pull request does a bunch of cool things. The primary goal was to have RequireJS load Popcorn, and as a side-effect we get:

1) Nuke the whole concept of external assets loaded by the server being different from the JS, eliminating a whole class of "which file do I edit to get my new plugin loaded"
2) IE9 shims will _always_ load before app code
3) We only load a single JS file now, so faster loading times
4) The r.js optimizer will concat all of the Popcorn files into `embed.js` so that we'll eventually be able to remove all of our build-related code for that

:yum: 

This is only the first part; I'll do a similar thing for butter.js in another patch.
