### PR TITLE
Added GA setDomain method to track users across subdomains.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,8 +14,8 @@
   <script type="text/javascript">
     var _gaq = _gaq || [];
     _gaq.push(['_setAccount', 'UA-35433268-2']);
+    _gaq.push(['_setDomainName', 'webmaker.org']);
     _gaq.push(['_trackPageview']);
-    _gaq.push(['setDomain', 'webmaker.org']);
 
     (function() {
       var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;

--- a/public/templates/basic/index.html
+++ b/public/templates/basic/index.html
@@ -32,8 +32,8 @@
   <script type="text/javascript">
     var _gaq = _gaq || [];
     _gaq.push(['_setAccount', 'UA-35433268-2']);
+    _gaq.push(['_setDomainName', 'webmaker.org']);
     _gaq.push(['_trackPageview']);
-    _gaq.push(['setDomain', 'webmaker.org']);
 
     (function() {
       var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;

--- a/views/dashboard.jade
+++ b/views/dashboard.jade
@@ -179,8 +179,8 @@ html
     script
       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', 'UA-35433268-2']);
+      _gaq.push(['_setDomainName', 'webmaker.org']);
       _gaq.push(['_trackPageview']);
-      _gaq.push(['setDomain', 'webmaker.org']);
 
       (function() {
         var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;


### PR DESCRIPTION
This change allows us to see aggregate analytics (navigation summaries, etc.) for users that first land on webmaker.org and then navigate to popcorn.webmaker.org.

More info here: https://developers.google.com/analytics/devguides/collection/gajs/gaTrackingSite
