### PR TITLE
Bug #2945 - Stop the draggable update timeout if the track event which w...

### DIFF
--- a/public/src/util/dragndrop.js
+++ b/public/src/util/dragndrop.js
@@ -65,6 +65,14 @@ define( [ "core/eventmanager", "util/lang", "util/scroll-group" ],
         draggable,
         droppable;
 
+    // Bug #2945 - this array can be empty if delete was pressed and held at the
+    // same time that the left mouse button is clicked. We must call__onDraggableMouseUp
+    // manually because Chrome will ignore the next mouseup event.
+    if ( !draggables.length ) {
+      __onDraggableMouseUp();
+      return;
+    }
+
     __scroll = false;
 
     if ( __mouseDown ) {
@@ -141,7 +149,7 @@ define( [ "core/eventmanager", "util/lang", "util/scroll-group" ],
   function __onDraggableMouseUp() {
     window.removeEventListener( "dragstart", __onWindowDragStart, false );
     window.removeEventListener( "mousemove", __onDraggableDragged, false );
-    window.removeEventListener( "mousemove", __onDraggableMouseUp, false );
+    window.removeEventListener( "mouseup", __onDraggableMouseUp, false );
 
     if ( !__mouseDown ) {
       return;


### PR DESCRIPTION
...as originally dragged is deleted.

https://webmademovies.lighthouseapp.com/projects/65733-popcorn-maker/tickets/2945-crash-uncaught-typeerror-cannot-read-property-top-of-undefined#ticket-2945-26
