### PR TITLE
Update track-container.js

### DIFF
--- a/public/src/timeline/track-container.js
+++ b/public/src/timeline/track-container.js
@@ -301,6 +301,13 @@ define( [ "core/logger", "util/dragndrop", "./ghost-manager" ],
           if ( newStart < _nextEventMin ) {
             newStart = _nextEventMin;
           }
+          // Bug: it doesnt update 'from' status at editor/sequencer-editor.js
+          // When you resize track by left size 'from' of clip is not updated
+          if (trackEvent.popcornOptions.start - newStart > 0 ) sign=sign*(-1);
+          popcornOptions.from = Math.abs(
+            Math.abs(trackEvent.popcornOptions.start  - (trackEventView.element.offsetLeft / _container.clientWidth * _media.duration))
+            + (trackEvent.popcornOptions.from*sign)
+          );
 
           popcornOptions.start = newStart;
         }


### PR DESCRIPTION
When you resize a video track in the track-container area making it shorter/longer from the left side there is a bug. It is not possible to shorten a video track from the beginning it always does from the end.The same thing happens when you try to make it longer.

Now it is possible to shorten/lengthen the video from both sides :

 if (trackEvent.popcornOptions.start - newStart > 0 ) sign=sign_(-1);
          popcornOptions.from = Math.abs(
            Math.abs(trackEvent.popcornOptions.start  - (trackEventView.element.offsetLeft / _container.clientWidth \* _media.duration))
            + (trackEvent.popcornOptions.from_sign)
          );
